### PR TITLE
Feature: Add support for emitting SBOMs

### DIFF
--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -62,5 +62,6 @@ resource "apko_build" "example" {
 
 - `id` (String) The resulting fully-qualified digest (e.g. {repo}@sha256:deadbeef).
 - `image_ref` (String) The resulting fully-qualified digest (e.g. {repo}@sha256:deadbeef).
+- `sboms` (Map of String) Map of image digests to their SBOM.
 
 


### PR DESCRIPTION
:gift: These are surfaced via a new output `sboms` which is a map from the image digest to it's SBOM.

depends on https://github.com/chainguard-dev/terraform-provider-apko/pull/42

/kind feature