### PR TITLE
Feature: Have `apko_build` take the loaded `apko_config`

### DIFF
--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -55,7 +55,7 @@ resource "apko_build" "example" {
 
 ### Required
 
-- `config` (String) The apko configuration file.
+- `config` (Object) The parsed structure of the apko configuration. (see [below for nested schema](#nestedatt--config))
 - `repo` (String) The name of the container repository to which we should publish the image.
 
 ### Read-Only
@@ -63,6 +63,152 @@ resource "apko_build" "example" {
 - `id` (String) The resulting fully-qualified digest (e.g. {repo}@sha256:deadbeef).
 - `image_ref` (String) The resulting fully-qualified digest (e.g. {repo}@sha256:deadbeef).
 - `sboms` (Map of Object) A map from the APK architecture to the digest for that architecture and its SBOM. (see [below for nested schema](#nestedatt--sboms))
+
+<a id="nestedatt--config"></a>
+### Nested Schema for `config`
+
+Required:
+
+- `accounts` (Object) (see [below for nested schema](#nestedobjatt--config--accounts))
+- `annotations` (Map of String)
+- `archs` (List of String)
+- `cmd` (String)
+- `contents` (Object) (see [below for nested schema](#nestedobjatt--config--contents))
+- `entrypoint` (Object) (see [below for nested schema](#nestedobjatt--config--entrypoint))
+- `environment` (Map of String)
+- `include` (String)
+- `options` (Map of Object) (see [below for nested schema](#nestedobjatt--config--options))
+- `os-release` (Object) (see [below for nested schema](#nestedobjatt--config--os-release))
+- `paths` (List of Object) (see [below for nested schema](#nestedobjatt--config--paths))
+- `stop-signal` (String)
+- `vcs-url` (String)
+- `work-dir` (String)
+
+<a id="nestedobjatt--config--accounts"></a>
+### Nested Schema for `config.accounts`
+
+Required:
+
+- `groups` (List of Object) (see [below for nested schema](#nestedobjatt--config--accounts--groups))
+- `run-as` (String)
+- `users` (List of Object) (see [below for nested schema](#nestedobjatt--config--accounts--users))
+
+<a id="nestedobjatt--config--accounts--groups"></a>
+### Nested Schema for `config.accounts.groups`
+
+Required:
+
+- `gid` (Number)
+- `groupname` (String)
+- `members` (List of String)
+
+
+<a id="nestedobjatt--config--accounts--users"></a>
+### Nested Schema for `config.accounts.users`
+
+Required:
+
+- `gid` (Number)
+- `uid` (Number)
+- `username` (String)
+
+
+
+<a id="nestedobjatt--config--contents"></a>
+### Nested Schema for `config.contents`
+
+Required:
+
+- `keyring` (List of String)
+- `packages` (List of String)
+- `repositories` (List of String)
+
+
+<a id="nestedobjatt--config--entrypoint"></a>
+### Nested Schema for `config.entrypoint`
+
+Required:
+
+- `command` (String)
+- `services` (Map of String)
+- `shell-fragment` (String)
+- `type` (String)
+
+
+<a id="nestedobjatt--config--options"></a>
+### Nested Schema for `config.options`
+
+Required:
+
+- `accounts` (Object) (see [below for nested schema](#nestedobjatt--config--options--accounts))
+- `contents` (Object) (see [below for nested schema](#nestedobjatt--config--options--contents))
+- `entrypoint` (Object) (see [below for nested schema](#nestedobjatt--config--options--entrypoint))
+- `environment` (Map of String)
+
+<a id="nestedobjatt--config--options--accounts"></a>
+### Nested Schema for `config.options.accounts`
+
+Required:
+
+- `run-as` (String)
+
+
+<a id="nestedobjatt--config--options--contents"></a>
+### Nested Schema for `config.options.contents`
+
+Required:
+
+- `packages` (Object) (see [below for nested schema](#nestedobjatt--config--options--contents--packages))
+
+<a id="nestedobjatt--config--options--contents--packages"></a>
+### Nested Schema for `config.options.contents.packages`
+
+Required:
+
+- `add` (List of String)
+- `remove` (List of String)
+
+
+
+<a id="nestedobjatt--config--options--entrypoint"></a>
+### Nested Schema for `config.options.entrypoint`
+
+Required:
+
+- `command` (String)
+- `services` (Map of String)
+- `shell-fragment` (String)
+- `type` (String)
+
+
+
+<a id="nestedobjatt--config--os-release"></a>
+### Nested Schema for `config.os-release`
+
+Required:
+
+- `bug-report-url` (String)
+- `home-url` (String)
+- `id` (String)
+- `name` (String)
+- `pretty-name` (String)
+- `version-id` (String)
+
+
+<a id="nestedobjatt--config--paths"></a>
+### Nested Schema for `config.paths`
+
+Required:
+
+- `gid` (Number)
+- `path` (String)
+- `permissions` (Number)
+- `recursive` (Boolean)
+- `source` (String)
+- `type` (String)
+- `uid` (Number)
+
+
 
 <a id="nestedatt--sboms"></a>
 ### Nested Schema for `sboms`

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"reflect"
 
 	apkotypes "chainguard.dev/apko/pkg/build/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -38,7 +37,7 @@ type ConfigDataSourceModel struct {
 var imageConfigurationSchema basetypes.ObjectType
 
 func init() {
-	sch, err := generateType(reflect.TypeOf(apkotypes.ImageConfiguration{}))
+	sch, err := generateType(apkotypes.ImageConfiguration{})
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +115,7 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		ic.Archs[i] = apkotypes.Architecture(a.ToAPK())
 	}
 
-	ov, diags := generateValue(reflect.ValueOf(ic))
+	ov, diags := generateValue(ic)
 	resp.Diagnostics = append(resp.Diagnostics, diags...)
 	if diags.HasError() {
 		return

--- a/internal/provider/reflect.go
+++ b/internal/provider/reflect.go
@@ -163,8 +163,6 @@ func assignValue(in attr.Value, out any) diag.Diagnostics {
 
 func assignValueReflect(in attr.Value, out reflect.Value) diag.Diagnostics {
 	t := out.Type()
-	// fmt.Printf("TYPE: %v %t\n", t, out.CanSet())
-
 	switch t.Kind() {
 	case reflect.Pointer:
 		return assignValueReflect(in, out.Elem())
@@ -218,7 +216,6 @@ func assignValueReflect(in attr.Value, out reflect.Value) diag.Diagnostics {
 
 		out = indirect(out)
 		t = out.Type()
-		// fmt.Printf("SLICE TYPE: %v %t\n", t, out.CanSet())
 
 		// Set the slice capacity appropriately (based on encoding/json)
 		l := len(elts)
@@ -248,7 +245,6 @@ func assignValueReflect(in attr.Value, out reflect.Value) diag.Diagnostics {
 
 		out = indirect(out)
 		t = out.Type()
-		// fmt.Printf("MAP TYPE: %v %t\n", t, out.CanSet())
 
 		if out.IsNil() {
 			out.Set(reflect.MakeMap(t))
@@ -274,7 +270,6 @@ func assignValueReflect(in attr.Value, out reflect.Value) diag.Diagnostics {
 
 		out = indirect(out)
 		t = out.Type()
-		// fmt.Printf("STRUCT TYPE: %v %t\n", t, out.CanSet())
 
 		for i := 0; i < t.NumField(); i++ {
 			sf := t.Field(i)

--- a/internal/provider/reflect.go
+++ b/internal/provider/reflect.go
@@ -10,7 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-func generateType(t reflect.Type) (attr.Type, error) {
+func generateType(v any) (attr.Type, error) {
+	return generateTypeReflect(reflect.TypeOf(v))
+}
+
+func generateTypeReflect(t reflect.Type) (attr.Type, error) {
 	switch t.Kind() {
 	case reflect.String:
 		return basetypes.StringType{}, nil
@@ -23,7 +27,7 @@ func generateType(t reflect.Type) (attr.Type, error) {
 		return basetypes.Float64Type{}, nil
 
 	case reflect.Array, reflect.Slice:
-		st, err := generateType(t.Elem())
+		st, err := generateTypeReflect(t.Elem())
 		if err != nil {
 			return nil, fmt.Errorf("[]%v: %w", t.Elem(), err)
 		}
@@ -35,7 +39,7 @@ func generateType(t reflect.Type) (attr.Type, error) {
 		if t.Key().Kind() != reflect.String {
 			return nil, fmt.Errorf("%v only string map keys are supported", t.Key())
 		}
-		et, err := generateType(t.Elem())
+		et, err := generateTypeReflect(t.Elem())
 		if err != nil {
 			return nil, fmt.Errorf("map[string]%v: %w", t.Elem(), err)
 		}
@@ -53,7 +57,7 @@ func generateType(t reflect.Type) (attr.Type, error) {
 			if tag == nil {
 				continue
 			}
-			ft, err := generateType(sf.Type)
+			ft, err := generateTypeReflect(sf.Type)
 			if err != nil {
 				return nil, fmt.Errorf("struct %w", err)
 			}
@@ -66,9 +70,15 @@ func generateType(t reflect.Type) (attr.Type, error) {
 	}
 }
 
-func generateValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
+func generateValue(v any) (attr.Value, diag.Diagnostics) {
+	return generateValueReflect(reflect.ValueOf(v))
+}
+
+func generateValueReflect(v reflect.Value) (attr.Value, diag.Diagnostics) {
 	t := v.Type()
 	switch t.Kind() {
+	case reflect.Pointer:
+		return generateValueReflect(v.Elem())
 	case reflect.String:
 		return basetypes.NewStringValue(v.String()), nil
 	case reflect.Bool:
@@ -81,13 +91,13 @@ func generateValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
 		return basetypes.NewFloat64Value(v.Float()), nil
 
 	case reflect.Array, reflect.Slice:
-		st, err := generateType(t.Elem())
+		st, err := generateTypeReflect(t.Elem())
 		if err != nil {
 			return nil, []diag.Diagnostic{diag.NewErrorDiagnostic(err.Error(), "")}
 		}
 		ets := make([]attr.Value, 0, v.Len())
 		for i := 0; i < v.Len(); i++ {
-			et, diags := generateValue(v.Index(i))
+			et, diags := generateValueReflect(v.Index(i))
 			if diags.HasError() {
 				return nil, diags
 			}
@@ -96,13 +106,14 @@ func generateValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
 		return basetypes.NewListValue(st, ets)
 
 	case reflect.Map:
-		et, err := generateType(t.Elem())
+		et, err := generateTypeReflect(t.Elem())
 		if err != nil {
 			return nil, []diag.Diagnostic{diag.NewErrorDiagnostic(err.Error(), "")}
 		}
+
 		em := make(map[string]attr.Value, v.Len())
 		for _, key := range v.MapKeys() {
-			et, diags := generateValue(v.MapIndex(key))
+			et, diags := generateValueReflect(v.MapIndex(key))
 			if diags.HasError() {
 				return nil, diags
 			}
@@ -111,7 +122,7 @@ func generateValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
 		return basetypes.NewMapValue(et, em)
 
 	case reflect.Struct:
-		ot, err := generateType(t)
+		ot, err := generateTypeReflect(t)
 		if err != nil {
 			return nil, []diag.Diagnostic{diag.NewErrorDiagnostic(err.Error(), "")}
 		}
@@ -123,7 +134,7 @@ func generateValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
 			if tag == nil {
 				continue
 			}
-			ft, diags := generateValue(v.Field(i))
+			ft, diags := generateValueReflect(v.Field(i))
 			if diags.HasError() {
 				return nil, diags
 			}
@@ -133,6 +144,163 @@ func generateValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
 
 	default:
 		return nil, []diag.Diagnostic{diag.NewErrorDiagnostic("unknown type", t.Kind().String())}
+	}
+}
+
+func assignValue(in attr.Value, out any) diag.Diagnostics {
+	rv := reflect.ValueOf(out)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return []diag.Diagnostic{diag.NewErrorDiagnostic("not a pointer or nil", fmt.Sprintf("got: %T", out))}
+	}
+
+	// This is copied from encoding/json
+	if rv.Kind() != reflect.Pointer && rv.Type().Name() != "" && rv.CanAddr() {
+		rv = rv.Addr()
+	}
+
+	return assignValueReflect(in, rv)
+}
+
+func assignValueReflect(in attr.Value, out reflect.Value) diag.Diagnostics {
+	t := out.Type()
+	// fmt.Printf("TYPE: %v %t\n", t, out.CanSet())
+
+	switch t.Kind() {
+	case reflect.Pointer:
+		return assignValueReflect(in, out.Elem())
+
+	case reflect.String:
+		sv, ok := in.(basetypes.StringValue)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not a string", fmt.Sprintf("got: %T", in))}
+		}
+		out.SetString(sv.ValueString())
+		return nil
+
+	case reflect.Bool:
+		bv, ok := in.(basetypes.BoolValue)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not a bool", fmt.Sprintf("got: %T", in))}
+		}
+		out.SetBool(bv.ValueBool())
+		return nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		iv, ok := in.(basetypes.Int64Value)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not an int64", fmt.Sprintf("got: %T", in))}
+		}
+		out.SetInt(iv.ValueInt64())
+		return nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		iv, ok := in.(basetypes.Int64Value)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not an int64", fmt.Sprintf("got: %T", in))}
+		}
+		out.SetUint(uint64(iv.ValueInt64()))
+		return nil
+
+	case reflect.Float32, reflect.Float64:
+		fv, ok := in.(basetypes.Float64Value)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not a float", fmt.Sprintf("got: %T", in))}
+		}
+		out.SetFloat(fv.ValueFloat64())
+		return nil
+
+	case reflect.Slice:
+		lv, ok := in.(basetypes.ListValue)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not a list", fmt.Sprintf("got: %T", in))}
+		}
+		elts := lv.Elements()
+
+		out = indirect(out)
+		t = out.Type()
+		// fmt.Printf("SLICE TYPE: %v %t\n", t, out.CanSet())
+
+		// Set the slice capacity appropriately (based on encoding/json)
+		l := len(elts)
+		if l > out.Cap() {
+			newv := reflect.MakeSlice(t, out.Len(), l)
+			reflect.Copy(newv, out)
+			out.Set(newv)
+		}
+		if l >= out.Len() {
+			out.SetLen(l)
+		}
+
+		// Copy into each of the elements.
+		for i, elt := range elts {
+			if diags := assignValueReflect(elt, out.Index(i)); diags.HasError() {
+				return diags
+			}
+		}
+		return nil
+
+	case reflect.Map:
+		mv, ok := in.(basetypes.MapValue)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not a map", fmt.Sprintf("got: %T", in))}
+		}
+		elts := mv.Elements()
+
+		out = indirect(out)
+		t = out.Type()
+		// fmt.Printf("MAP TYPE: %v %t\n", t, out.CanSet())
+
+		if out.IsNil() {
+			out.Set(reflect.MakeMap(t))
+		}
+
+		for key, val := range elts {
+			k := reflect.ValueOf(key)
+
+			v := reflect.New(t.Elem()).Elem()
+			if diags := assignValueReflect(val, v); diags.HasError() {
+				return diags
+			}
+			out.SetMapIndex(k, v)
+		}
+		return nil
+
+	case reflect.Struct:
+		ov, ok := in.(basetypes.ObjectValue)
+		if !ok {
+			return []diag.Diagnostic{diag.NewErrorDiagnostic("not a object", fmt.Sprintf("got: %T", in))}
+		}
+		fl := ov.Attributes()
+
+		out = indirect(out)
+		t = out.Type()
+		// fmt.Printf("STRUCT TYPE: %v %t\n", t, out.CanSet())
+
+		for i := 0; i < t.NumField(); i++ {
+			sf := t.Field(i)
+			tag := yamlName(sf)
+			if tag == nil {
+				continue
+			}
+			val, ok := fl[*tag]
+			if !ok {
+				continue
+			}
+			diags := assignValueReflect(val, out.Field(i))
+			if diags.HasError() {
+				return diags
+			}
+			delete(fl, *tag)
+		}
+
+		diags := make([]diag.Diagnostic, 0, len(fl))
+		for k := range fl {
+			diags = append(diags, diag.NewErrorDiagnostic("unmatched field", fmt.Sprintf("%s was not found in struct", k)))
+		}
+		return diags
+
+	default:
+		return []diag.Diagnostic{diag.NewErrorDiagnostic("unknown type", t.Kind().String())}
 	}
 }
 
@@ -150,4 +318,69 @@ func yamlName(field reflect.StructField) *string {
 	}
 	fn := strings.ToLower(field.Name)
 	return &fn
+}
+
+// indirect walks down v allocating pointers as needed,
+// until it gets to a non-pointer.
+// If it encounters an Unmarshaler, indirect stops and returns that.
+// If decodingNull is true, indirect stops at the first settable pointer so it
+// can be set to nil.
+// This is copied/modified from encoding/json
+func indirect(v reflect.Value) reflect.Value {
+	// Issue #24153 indicates that it is generally not a guaranteed property
+	// that you may round-trip a reflect.Value by calling Value.Addr().Elem()
+	// and expect the value to still be settable for values derived from
+	// unexported embedded struct fields.
+	//
+	// The logic below effectively does this when it first addresses the value
+	// (to satisfy possible pointer methods) and continues to dereference
+	// subsequent pointers as necessary.
+	//
+	// After the first round-trip, we set v back to the original value to
+	// preserve the original RW flags contained in reflect.Value.
+	v0 := v
+	haveAddr := false
+
+	// If v is a named type and is addressable,
+	// start with its address, so that if the type has pointer methods,
+	// we find them.
+	if v.Kind() != reflect.Pointer && v.Type().Name() != "" && v.CanAddr() {
+		haveAddr = true
+		v = v.Addr()
+	}
+	for {
+		// Load value from interface, but only if the result will be
+		// usefully addressable.
+		if v.Kind() == reflect.Interface && !v.IsNil() {
+			e := v.Elem()
+			if e.Kind() == reflect.Pointer && !e.IsNil() {
+				haveAddr = false
+				v = e
+				continue
+			}
+		}
+
+		if v.Kind() != reflect.Pointer {
+			break
+		}
+
+		// Prevent infinite loop if v is an interface pointing to its own address:
+		//     var v interface{}
+		//     v = &v
+		if v.Elem().Kind() == reflect.Interface && v.Elem().Elem() == v {
+			v = v.Elem()
+			break
+		}
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+
+		if haveAddr {
+			v = v0 // restore original value after round-trip Value.Addr().Elem()
+			haveAddr = false
+		} else {
+			v = v.Elem()
+		}
+	}
+	return v
 }


### PR DESCRIPTION
:gift: This changes the type of `apko_build.config` to take the schematized APKO config.

Users can now pass a structured APKO configuration directly to `apko_build` or load it via `apko_config` and pass it through.

🚨  THIS IS A BREAKING CHANGE 🚨 

WIP until https://github.com/chainguard-dev/terraform-provider-apko/pull/51 merges

/kind feature