### PR TITLE
Feature: Have `apko_config` "lock" the configuration as much as it can.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	chainguard.dev/apko v0.8.1-0.20230505234243-87f7f0ff54fa
 	github.com/chainguard-dev/terraform-provider-oci v0.0.0-20230426201150-f82273dff08e
+	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.14.1-0.20230425172351-b7c6e9dc3944
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
@@ -14,6 +15,8 @@ require (
 	github.com/sigstore/cosign/v2 v2.0.3-0.20230425232139-17cc13812d8a
 	golang.org/x/sync v0.1.0
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/apimachinery v0.26.1
+	knative.dev/pkg v0.0.0-20230502134655-db8a35330281
 )
 
 require (
@@ -87,7 +90,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-chainguard.dev/apko v0.7.4-0.20230421200506-66070a941bd0 h1:UpFkquDnEIZ1V4+S/UrHGxFp11smFWRGTaWgqLMEGek=
-chainguard.dev/apko v0.7.4-0.20230421200506-66070a941bd0/go.mod h1:+/nr2VHPIDEJqsUpY/WvYDrkzCe7WoL5RBW28NQVKUs=
-chainguard.dev/apko v0.8.0 h1:Ee46H52mn9nvAL2X/nxIIXMsXd4wzTgpgFr+T5bKIp8=
-chainguard.dev/apko v0.8.0/go.mod h1:avKgL6ETv4Gz5HbDSMvShwACob60CSaf82vMsRdOKds=
 chainguard.dev/apko v0.8.1-0.20230505234243-87f7f0ff54fa h1:MFDVtY/Eq2bmUoq+STYXqkXU6aoMbO+skQr7IOCHWIo=
 chainguard.dev/apko v0.8.1-0.20230505234243-87f7f0ff54fa/go.mod h1:SsTPoLjaKWaTDLAnJuG7KneTH+c5Eb/9L8ZvvaZ41po=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -130,7 +126,6 @@ github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSk
 github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -163,7 +158,6 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
-github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
@@ -274,15 +268,11 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-containerregistry v0.14.1-0.20230409045903-ed5c185df419 h1:gMlTWagRJgCJ3EnISyF5+p9phYpFyWEI70Z56T+o2MY=
-github.com/google/go-containerregistry v0.14.1-0.20230409045903-ed5c185df419/go.mod h1:ETSJmRH9iO4Q0WQILIMkDUiKk+CaxItZW+gEDjyw8Ug=
 github.com/google/go-containerregistry v0.14.1-0.20230425172351-b7c6e9dc3944 h1:7c5khUnWebZDFMUQ7rf2vynmmnKI1VvBACrTZKKpoD4=
 github.com/google/go-containerregistry v0.14.1-0.20230425172351-b7c6e9dc3944/go.mod h1:0JopT7wiZeP5/ATNgx85oApuNAiNnfn4mr8+WOssYNQ=
-github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -384,7 +374,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
-github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -449,7 +438,6 @@ github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a/go.mod
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -469,9 +457,7 @@ github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e/go.mod h1:tcaRap0jS
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -481,8 +467,6 @@ github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NF
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sigstore/cosign/v2 v2.0.2 h1:Ttaj/OkJAy+ummhnHG2F+JSFeZQj8i0P6o8j2RY9NG4=
-github.com/sigstore/cosign/v2 v2.0.2/go.mod h1:yJXtRmWrumyQA/XPjTTjOufnNckI87mmmVxv9rtEqgE=
 github.com/sigstore/cosign/v2 v2.0.3-0.20230425232139-17cc13812d8a h1:spJ3NgeJEGZpu3FUdJ15YBlKyFDXk+SHiwsxIPGYCGg=
 github.com/sigstore/cosign/v2 v2.0.3-0.20230425232139-17cc13812d8a/go.mod h1:w/EZWhMlRKVxmhERurreLboT4NRjZgH/F+9Yv5I1mIQ=
 github.com/sigstore/rekor v1.1.0 h1:9fjPvW0WERE7VPtSSVSTbDLLOsrNx3RtiIeZ4/1tmDI=
@@ -552,8 +536,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.1 h1:0a6bRwuiSHtAmqCqNOE+c2oHgepv0ctoxU4FUe43kwc=
 github.com/zclconf/go-cty v1.13.1/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
-gitlab.alpinelinux.org/alpine/go v0.6.0 h1:cVhjjEMYdb8dOAECvIKjE1my1TBJCjcG61P4On7cK1Y=
-gitlab.alpinelinux.org/alpine/go v0.6.0/go.mod h1:nqCQNE3MNmF1c6SNGiJbvgzxUqOLKT6f9IyJY52WyJU=
 gitlab.alpinelinux.org/alpine/go v0.7.0 h1:N1uWANXNTdu9soAl1eXSs2SQ+gNV4dE0zfJzNG64DeY=
 gitlab.alpinelinux.org/alpine/go v0.7.0/go.mod h1:maZIvJ1++n6Tc3VI+Ta2Sys2OjEmuoXhd92aRzeIjZI=
 go.lsp.dev/uri v0.3.0 h1:KcZJmh6nFIBeJzTugn5JTU6OOyG0lDOo3R9KwTxTYbo=
@@ -668,7 +650,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -785,8 +766,10 @@ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.1.0 h1:rVV8Tcg/8jHUkPUorwjaMTtemIMVXfIPKiOqnhEhakk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-mvdan.cc/editorconfig v0.2.0/go.mod h1:lvnnD3BNdBYkhq+B4uBuFFKatfp02eB6HixDvEz91C0=
-mvdan.cc/sh/v3 v3.5.1/go.mod h1:1JcoyAKm1lZw/2bZje/iYKWicU/KMd0rsyJeKHnsK4E=
+k8s.io/apimachinery v0.26.1 h1:8EZ/eGJL+hY/MYCNwhmDzVqq2lPl3N3Bo8rvweJwXUQ=
+k8s.io/apimachinery v0.26.1/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
+knative.dev/pkg v0.0.0-20230502134655-db8a35330281 h1:9mN8O5XO68DKlkzEhFAShUx+O/I+TQR71vmTvYt8oF4=
+knative.dev/pkg v0.0.0-20230502134655-db8a35330281/go.mod h1:2qWPP9Gjh9Q7ETti+WRHnBnGCSCq+6q7m3p/nmUQviE=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/release-utils v0.7.3 h1:6pS8x6c5RmdUgR9qcg1LO6hjUzuE4Yo9TGZ3DemrZdM=
 sigs.k8s.io/release-utils v0.7.3/go.mod h1:n0mVez/1PZYZaZUTJmxewxH3RJ/Lf7JUDh7TG1CASOE=

--- a/internal/provider/config_data_source_test.go
+++ b/internal/provider/config_data_source_test.go
@@ -1,11 +1,15 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestAccDataSourceConfig(t *testing.T) {
@@ -44,7 +48,47 @@ data "apko_config" "this" {
 	})
 }
 
-func TestAccDataSourceConfig_ProviderOpts(t *testing.T) {
+func TestAccDataSourceConfig_ProviderOpts_Locked(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"apko": providerserver.NewProtocol6WithError(&Provider{
+				repositories: []string{"https://packages.wolfi.dev/os"},
+				keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
+				archs:        []string{"x86_64", "aarch64"},
+				packages:     []string{"wolfi-baselayout=20230201-r0"},
+			}),
+		},
+		Steps: []resource.TestStep{{
+			Config: `
+data "apko_config" "this" {
+  config_contents = <<EOF
+contents:
+  packages:
+    - ca-certificates-bundle=20230506-r0
+    - glibc-locale-posix=2.37-r6
+    - tzdata=2023c-r0
+  EOF
+}`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.archs.#", "2"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.archs.0", "x86_64"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.archs.1", "aarch64"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.#", "4"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.0", "ca-certificates-bundle=20230506-r0"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.1", "glibc-locale-posix=2.37-r6"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.2", "tzdata=2023c-r0"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.3", "wolfi-baselayout=20230201-r0"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.repositories.#", "1"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.repositories.0", "https://packages.wolfi.dev/os"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.keyring.#", "1"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.keyring.0", "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"),
+			),
+		}},
+	})
+}
+
+func TestAccDataSourceConfig_ProviderOpts_Unlocked(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
@@ -69,10 +113,12 @@ contents:
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.archs.#", "2"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.archs.0", "x86_64"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.archs.1", "aarch64"),
-				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.#", "3"),
-				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.0", "ca-certificates-bundle"),
-				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.1", "tzdata"),
-				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.2", "wolfi-baselayout"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.#", "4"),
+				resource.TestMatchResourceAttr("data.apko_config.this", "config.contents.packages.0", regexp.MustCompile("^ca-certificates-bundle=.*")),
+				// This is pulled in as a transitive dependency.
+				resource.TestMatchResourceAttr("data.apko_config.this", "config.contents.packages.1", regexp.MustCompile("^glibc-locale-posix=.*")),
+				resource.TestMatchResourceAttr("data.apko_config.this", "config.contents.packages.2", regexp.MustCompile("^tzdata=.*")),
+				resource.TestMatchResourceAttr("data.apko_config.this", "config.contents.packages.3", regexp.MustCompile("^wolfi-baselayout=.*")),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.repositories.#", "1"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.repositories.0", "https://packages.wolfi.dev/os"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.keyring.#", "1"),
@@ -80,4 +126,230 @@ contents:
 			),
 		}},
 	})
+}
+
+func TestUnify(t *testing.T) {
+	tests := []struct {
+		name      string
+		originals []string
+		inputs    []resolved
+		want      []string
+		wantDiag  diag.Diagnostics
+	}{{
+		name: "empty",
+	}, {
+		name:      "simple single arch",
+		originals: []string{"foo", "bar", "baz"},
+		inputs: []resolved{{
+			packages: sets.New("foo", "bar", "baz"),
+			versions: map[string]string{
+				"foo": "1.2.3",
+				"bar": "2.4.6",
+				"baz": "0.0.1",
+			},
+		}},
+		want: []string{
+			"bar=2.4.6",
+			"baz=0.0.1",
+			"foo=1.2.3",
+		},
+	}, {
+		name:      "locked versions",
+		originals: []string{"foo=1.2.3", "bar=2.4.6", "baz=0.0.1"},
+		inputs: []resolved{{
+			packages: sets.New("foo", "bar", "baz"),
+			versions: map[string]string{
+				"foo": "1.2.3",
+				"bar": "2.4.6",
+				"baz": "0.0.1",
+			},
+		}},
+		want: []string{
+			"bar=2.4.6",
+			"baz=0.0.1",
+			"foo=1.2.3",
+		},
+	}, {
+		name:      "transitive dependency",
+		originals: []string{"foo", "bar", "baz"},
+		inputs: []resolved{{
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3",
+			},
+		}},
+		want: []string{
+			"bar=2.4.6",
+			"baz=0.0.1",
+			"bonus=5.4.3",
+			"foo=1.2.3",
+		},
+	}, {
+		name:      "multiple matching architectures",
+		originals: []string{"foo", "bar", "baz"},
+		inputs: []resolved{{
+			arch:     "x86_64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3",
+			},
+		}, {
+			arch:     "aarch64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3",
+			},
+		}},
+		want: []string{
+			"bar=2.4.6",
+			"baz=0.0.1",
+			"bonus=5.4.3",
+			"foo=1.2.3",
+		},
+	}, {
+		name:      "mismatched transitive dependency",
+		originals: []string{"foo", "bar", "baz"},
+		inputs: []resolved{{
+			arch:     "x86_64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3-r0",
+			},
+		}, {
+			arch:     "aarch64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3-r1",
+			},
+		}},
+		want: []string{
+			"bar=2.4.6",
+			"baz=0.0.1",
+			"foo=1.2.3",
+		},
+		wantDiag: []diag.Diagnostic{
+			diag.NewWarningDiagnostic("unable to lock certain packages for x86_64", "[bonus]"),
+			diag.NewWarningDiagnostic("unable to lock certain packages for aarch64", "[bonus]"),
+		},
+	}, {
+		name:      "mismatched direct dependency",
+		originals: []string{"foo", "bar", "baz"},
+		inputs: []resolved{{
+			arch:     "x86_64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6-r0",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3",
+			},
+		}, {
+			arch:     "aarch64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6-r1",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3",
+			},
+		}},
+		want: []string{
+			"bar",
+			"baz=0.0.1",
+			"bonus=5.4.3",
+			"foo=1.2.3",
+		},
+		wantDiag: []diag.Diagnostic{
+			diag.NewWarningDiagnostic("unable to lock certain packages", "[bar]"),
+		},
+	}, {
+		name:      "mismatched direct dependency (with constraint)",
+		originals: []string{"foo", "bar>2.4.6", "baz"},
+		inputs: []resolved{{
+			arch:     "x86_64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6-r0",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3",
+			},
+		}, {
+			arch:     "aarch64",
+			packages: sets.New("foo", "bar", "baz", "bonus"),
+			versions: map[string]string{
+				"foo":   "1.2.3",
+				"bar":   "2.4.6-r1",
+				"baz":   "0.0.1",
+				"bonus": "5.4.3",
+			},
+		}},
+		want: []string{
+			"bar>2.4.6", // Check that we keep our input constraint
+			"baz=0.0.1",
+			"bonus=5.4.3",
+			"foo=1.2.3",
+		},
+		wantDiag: []diag.Diagnostic{
+			diag.NewWarningDiagnostic("unable to lock certain packages", "[bar]"),
+		},
+	}, {
+		name:      "single-architecture resolved dependency",
+		originals: []string{"foo", "bar", "baz"},
+		inputs: []resolved{{
+			arch:     "x86_64",
+			packages: sets.New("foo", "bar", "baz", "intel-fast-as-f-math"),
+			versions: map[string]string{
+				"foo":                  "1.2.3",
+				"bar":                  "2.4.6",
+				"baz":                  "0.0.1",
+				"intel-fast-as-f-math": "5.4.3",
+			},
+		}, {
+			arch:     "aarch64",
+			packages: sets.New("foo", "bar", "baz", "arm-energy-efficient-as-f-arithmetic"),
+			versions: map[string]string{
+				"foo":                                  "1.2.3",
+				"bar":                                  "2.4.6",
+				"baz":                                  "0.0.1",
+				"arm-energy-efficient-as-f-arithmetic": "9.8.7",
+			},
+		}},
+		want: []string{
+			"bar=2.4.6",
+			"baz=0.0.1",
+			"foo=1.2.3",
+		},
+		wantDiag: []diag.Diagnostic{
+			diag.NewWarningDiagnostic("unable to lock certain packages for x86_64", "[intel-fast-as-f-math]"),
+			diag.NewWarningDiagnostic("unable to lock certain packages for aarch64", "[arm-energy-efficient-as-f-arithmetic]"),
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotDiag := unify(test.originals, test.inputs)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("(-want, +got) = %s", diff)
+			}
+			if diff := cmp.Diff(test.wantDiag, gotDiag); diff != "" {
+				t.Errorf("(-want, +got) = %s", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
:gift: This changes the structured output of `apko_config` to resolve the transitive dependencies in the `apko.yaml` configuration as much as possible for consistency across the target architectures.

For example, if a user config specifies the following:
```yaml
contents:
  packages:
    - ca-certificates-bundle
    - tzdata
    - wolfi-baselayout
```

The resolved configuration might look like:
```yaml
contents:
  packages:
    - ca-certificates-bundle=20230506-r0
    - glibc-locale-posix=2.37-r6
    - tzdata=2023c-r0
    - wolfi-baselayout=20230201-r0
```

If there are packages that resolve inconsistently across architectures, we will either preserve their input constraint (if a direct dependency) or elide it (if a transitive dependency).

This change allows us to do interesting things like attest to the locked configuration used to drive the APKO build :tada:

/kind feature