### PR TITLE
Cleanup: Rename the provider-level fields to increase clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ This provides an `apko_build` resource that will build the provided `apko` confi
 # with additional packages.
 provider "apko" {
   # Default to building for these architectures.
-  archs = ["x86_64", "aarch64"]
+  default_archs = ["x86_64", "aarch64"]
 
   # Include these repositories by default
-  repositories = ["https://packages.wolfi.dev/os"]
-  keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  extra_repositories = ["https://packages.wolfi.dev/os"]
+  extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
 
   # All of the images should show up as Wolfi!
-  packages     = ["wolfi-baselayout"]
+  extra_packages     = ["wolfi-baselayout"]
 }
 
 data "apko_config" "this" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ provider "apko" {}
 
 ### Optional
 
-- `archs` (List of String) Default architectures to build for
-- `keyring` (List of String) Additional keys to use for package verification
-- `packages` (List of String) Additional packages to install
-- `repositories` (List of String) Additional repositories to search for packages
+- `default_archs` (List of String) Default architectures to build for
+- `extra_keyring` (List of String) Additional keys to use for package verification
+- `extra_packages` (List of String) Additional packages to install
+- `extra_repositories` (List of String) Additional repositories to search for packages

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -36,9 +36,13 @@ func fromImageData(ic types.ImageConfiguration, popts ProviderOpts, wd string) (
 		return nil, err
 	}
 
-	if len(popts.archs) != 0 {
+	if len(bc.ImageConfiguration.Archs) != 0 {
+		// If the configuration has architectures, use them.
+	} else if len(popts.archs) != 0 {
+		// Otherwise, fallback on the provider architectures.
 		bc.ImageConfiguration.Archs = types.ParseArchitectures(popts.archs)
-	} else if len(bc.ImageConfiguration.Archs) == 0 {
+	} else {
+		// If neither is specified, build for all architectures!
 		bc.ImageConfiguration.Archs = types.AllArchs
 	}
 	return bc, nil

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -113,9 +113,12 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	ic.Contents.Packages = append(ic.Contents.Packages, d.popts.packages...)
 	ic.Contents.Keyring = append(ic.Contents.Keyring, d.popts.keyring...)
 
-	// Override config archs with provider archs, if specified.
-	if len(d.popts.archs) != 0 {
-		ic.Archs = apkotypes.ParseArchitectures(d.popts.archs)
+	// Default to the provider architectures when the image configuration
+	// doesn't specify any.
+	if len(ic.Archs) == 0 {
+		if len(d.popts.archs) != 0 {
+			ic.Archs = apkotypes.ParseArchitectures(d.popts.archs)
+		}
 	}
 
 	// Normalize the architectures we surface

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,10 +19,10 @@ type Provider struct {
 }
 
 type ProviderModel struct {
-	Repositories []string `tfsdk:"repositories"`
-	Packages     []string `tfsdk:"packages"`
-	Keyring      []string `tfsdk:"keyring"`
-	Archs        []string `tfsdk:"archs"`
+	ExtraRepositories []string `tfsdk:"extra_repositories"`
+	ExtraPackages     []string `tfsdk:"extra_packages"`
+	ExtraKeyring      []string `tfsdk:"extra_keyring"`
+	DefaultArchs      []string `tfsdk:"default_archs"`
 }
 
 type ProviderOpts struct {
@@ -37,22 +37,22 @@ func (p *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, r
 func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"repositories": schema.ListAttribute{
+			"extra_repositories": schema.ListAttribute{
 				Description: "Additional repositories to search for packages",
 				Optional:    true,
 				ElementType: basetypes.StringType{},
 			},
-			"packages": schema.ListAttribute{
+			"extra_packages": schema.ListAttribute{
 				Description: "Additional packages to install",
 				Optional:    true,
 				ElementType: basetypes.StringType{},
 			},
-			"keyring": schema.ListAttribute{
+			"extra_keyring": schema.ListAttribute{
 				Description: "Additional keys to use for package verification",
 				Optional:    true,
 				ElementType: basetypes.StringType{},
 			},
-			"archs": schema.ListAttribute{
+			"default_archs": schema.ListAttribute{
 				Description: "Default architectures to build for",
 				Optional:    true,
 				ElementType: basetypes.StringType{},
@@ -70,10 +70,10 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 
 	opts := &ProviderOpts{
 		// This is only for testing, so we can inject provider config
-		repositories: append(p.repositories, data.Repositories...),
-		packages:     append(p.packages, data.Packages...),
-		keyring:      append(p.keyring, data.Keyring...),
-		archs:        append(p.archs, data.Archs...),
+		repositories: append(p.repositories, data.ExtraRepositories...),
+		packages:     append(p.packages, data.ExtraPackages...),
+		keyring:      append(p.keyring, data.ExtraKeyring...),
+		archs:        append(p.archs, data.DefaultArchs...),
 	}
 
 	// Make provider opts available to resources and data sources.


### PR DESCRIPTION
:broom: This renames the provider-level fields to qualify them in ways that better convey their semantics contributing to the `apko_config`.

🚨 THIS IS A BREAKING CHANGE 🚨 

/kind cleanup