### PR TITLE
Feature: Compute/Surface "apk date epoch"

### DIFF
--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -21,6 +21,7 @@ This reads an apko configuration file into a structured form.
 
 ### Read-Only
 
+- `apk_date_epoch` (String) The most recent RFC3339-encoded build time of the resolved APKs.
 - `config` (Object) The parsed structure of the apko configuration. (see [below for nested schema](#nestedatt--config))
 - `id` (String) A unique identifier for this apko config.
 

--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -58,6 +58,10 @@ resource "apko_build" "example" {
 - `config` (Object) The parsed structure of the apko configuration. (see [below for nested schema](#nestedatt--config))
 - `repo` (String) The name of the container repository to which we should publish the image.
 
+### Optional
+
+- `timestamp` (String) The RFC3339-encoded timestamp to give the resulting image (defaults to Unix epoch).
+
 ### Read-Only
 
 - `id` (String) The resulting fully-qualified digest (e.g. {repo}@sha256:deadbeef).

--- a/internal/provider/resource_build.go
+++ b/internal/provider/resource_build.go
@@ -34,12 +34,13 @@ type BuildResource struct {
 }
 
 type BuildResourceModel struct {
-	Id       types.String `tfsdk:"id"`
-	Repo     types.String `tfsdk:"repo"`
-	Config   types.Object `tfsdk:"config"`
-	ImageRef types.String `tfsdk:"image_ref"`
+	Id        types.String `tfsdk:"id"`
+	Repo      types.String `tfsdk:"repo"`
+	Config    types.Object `tfsdk:"config"`
+	Timestamp types.String `tfsdk:"timestamp"`
 
-	SBOMs types.Map `tfsdk:"sboms"`
+	ImageRef types.String `tfsdk:"image_ref"`
+	SBOMs    types.Map    `tfsdk:"sboms"`
 
 	popts ProviderOpts // Data passed from the provider.
 }
@@ -95,6 +96,14 @@ func (r *BuildResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				AttributeTypes:      imageConfigurationSchema.AttrTypes,
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplace(),
+				},
+			},
+			"timestamp": schema.StringAttribute{
+				MarkdownDescription: "The RFC3339-encoded timestamp to give the resulting image (defaults to Unix epoch).",
+				Optional:            true,
+				Validators:          []validator.String{RFC3339Validator{}},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"image_ref": schema.StringAttribute{

--- a/internal/provider/resource_build_test.go
+++ b/internal/provider/resource_build_test.go
@@ -17,7 +17,7 @@ func TestAccResourceApkoBuild(t *testing.T) {
 
 	repostr := repo.String()
 
-	resource.Test(t, resource.TestCase{
+	resource.UnitTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -52,8 +52,9 @@ EOF
 }
 
 resource "apko_build" "foo" {
-  repo   = %q
-  config = data.apko_config.foo.config
+  repo      = %q
+  config    = data.apko_config.foo.config
+  timestamp = data.apko_config.foo.apk_date_epoch
 }
 `, repostr),
 				Check: resource.ComposeTestCheckFunc(
@@ -97,8 +98,9 @@ EOF
 }
 
 resource "apko_build" "foo" {
-	repo   = %q
-	config = data.apko_config.foo.config
+  repo      = %q
+  config    = data.apko_config.foo.config
+  timestamp = data.apko_config.foo.apk_date_epoch
 }`, repostr),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
@@ -117,7 +119,7 @@ func TestAccResourceApkoBuild_ProviderOpts(t *testing.T) {
 
 	repostr := repo.String()
 
-	resource.Test(t, resource.TestCase{
+	resource.UnitTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"apko": providerserver.NewProtocol6WithError(&Provider{
@@ -139,8 +141,9 @@ EOF
 }
 
 resource "apko_build" "foo" {
-	repo   = %q
-	config = data.apko_config.foo.config
+  repo      = %q
+  config    = data.apko_config.foo.config
+  timestamp = data.apko_config.foo.apk_date_epoch
 }
 `, repostr),
 				Check: resource.ComposeTestCheckFunc(
@@ -164,8 +167,9 @@ EOF
 }
 
 resource "apko_build" "foo" {
-	repo   = %q
-	config = data.apko_config.foo.config
+  repo      = %q
+  config    = data.apko_config.foo.config
+  timestamp = data.apko_config.foo.apk_date_epoch
 }
 `, repostr),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/provider/rfc3339_validator.go
+++ b/internal/provider/rfc3339_validator.go
@@ -1,0 +1,27 @@
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type RFC3339Validator struct{}
+
+var _ validator.String = RFC3339Validator{}
+
+func (v RFC3339Validator) Description(context.Context) string {
+	return "value must be a valid RFC3339-encoded timestamp"
+}
+func (v RFC3339Validator) MarkdownDescription(ctx context.Context) string { return v.Description(ctx) }
+
+func (v RFC3339Validator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	val := req.ConfigValue.ValueString()
+	if _, err := time.Parse(time.RFC3339, val); err != nil {
+		resp.Diagnostics.AddError("Invalid RFC3339-encoded timestamp", err.Error())
+	}
+}


### PR DESCRIPTION
:gift: This change surfaces a new `apk_date_epoch` from the `apko_config` rule, which contains the latest build date of the resolved APKs.

:gift: This change also surfaces a `timestamp` argument to `apko_build` to allow users to specify the build timestamp.

With these combined, users can get stable image build timestamps that only change when the APKs change (assuming the APKs carry build dates, which we are working on for Wolfi).

/kind feature