### PR TITLE
default to host arch when nothing is specified

### DIFF
--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -138,8 +138,8 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		if len(d.popts.archs) != 0 {
 			ic.Archs = apkotypes.ParseArchitectures(d.popts.archs)
 		} else {
-			// Default to host arch when provider and config data source don't specify any.
-			ic.Archs = apkotypes.ParseArchitectures([]string{"host"})
+			// Default to all archs when provider and config data source don't specify any.
+			ic.Archs = apkotypes.AllArchs
 		}
 	}
 

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -60,7 +60,6 @@ func (d *ConfigDataSource) Metadata(ctx context.Context, req datasource.Metadata
 }
 
 func (d *ConfigDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This reads an apko configuration file into a structured form.",
 		Attributes: map[string]schema.Attribute{
@@ -138,6 +137,9 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	if len(ic.Archs) == 0 {
 		if len(d.popts.archs) != 0 {
 			ic.Archs = apkotypes.ParseArchitectures(d.popts.archs)
+		} else {
+			// Default to host arch when provider and config data source don't specify any.
+			ic.Archs = apkotypes.ParseArchitectures([]string{"host"})
 		}
 	}
 


### PR DESCRIPTION
fixes the panic by defaulting to the `host` arch. though another valid soln is to raise an error message if we want that to be the default behavior!

fixes https://github.com/chainguard-dev/terraform-provider-apko/issues/63