### PR TITLE
rename extra_annotations -> default_annotations, add provider support

### DIFF
--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -18,7 +18,7 @@ This reads an apko configuration file into a structured form.
 ### Optional
 
 - `config_contents` (String) The raw contents of the apko configuration.
-- `extra_annotations` (Map of String) A map of extra annotations to add to the resulting image.
+- `default_annotations` (Map of String) Default annotations to add.
 - `extra_packages` (List of String) A list of extra packages to install.
 
 ### Read-Only

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ provider "apko" {}
 
 ### Optional
 
+- `default_annotations` (Map of String) Default annotations to add
 - `default_archs` (List of String) Default architectures to build for
 - `extra_keyring` (List of String) Additional keys to use for package verification
 - `extra_packages` (List of String) Additional packages to install

--- a/internal/provider/config_data_source_test.go
+++ b/internal/provider/config_data_source_test.go
@@ -57,6 +57,10 @@ func TestAccDataSourceConfig_ExtraPackages(t *testing.T) {
 				keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
 				archs:        []string{"x86_64", "aarch64"},
 				packages:     []string{"wolfi-baselayout=20230201-r0"},
+				anns: map[string]string{
+					"bar": "provider-provided",
+					"baz": "provider-provided",
+				},
 			}),
 		},
 		Steps: []resource.TestStep{{
@@ -71,9 +75,9 @@ annotations:
   bar: config-provided
 EOF
   extra_packages = ["tzdata=2023c-r0"]
-  extra_annotations = {
+  default_annotations = {
 	foo: "bar"
-	bar: "extra-provided"
+	bar: "datasource-provided"
   }
 }`,
 			Check: resource.ComposeTestCheckFunc(
@@ -82,8 +86,10 @@ EOF
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.1", "glibc-locale-posix=2.37-r6"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.2", "tzdata=2023c-r0"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.contents.packages.3", "wolfi-baselayout=20230201-r0"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.annotations.%", "3"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.annotations.foo", "bar"),
 				resource.TestCheckResourceAttr("data.apko_config.this", "config.annotations.bar", "config-provided"),
+				resource.TestCheckResourceAttr("data.apko_config.this", "config.annotations.baz", "provider-provided"),
 			),
 		}},
 	})


### PR DESCRIPTION
`default_annotations` feels like a more accurate description than `extra`, like `default_archs`.

The precedence is YAML config > datasource config > provider config