### PR TITLE
fix some data races

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,5 @@ jobs:
 
     - run: go mod download
     - run: go build -v .
+    # TODO(jason): Enable -race
     - run: TF_ACC=1 go test -v -cover ./internal/provider/

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -176,13 +176,6 @@ func (d *ConfigDataSource) resolvePackageList(ic apkotypes.ImageConfiguration) (
 	}
 	defer os.RemoveAll(workDir)
 
-	// Normalize the architecture by calling ParseArchitecture.  This is
-	// something subtle that `apko` gets for free because it only accepts yaml
-	// and the yaml parsing normalizes things.
-	for i, arch := range ic.Archs {
-		ic.Archs[i] = apkotypes.ParseArchitecture(arch.String())
-	}
-
 	eg := errgroup.Group{}
 	archs := make([]resolved, len(ic.Archs))
 	for i, arch := range ic.Archs {

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -176,6 +176,13 @@ func (d *ConfigDataSource) resolvePackageList(ic apkotypes.ImageConfiguration) (
 	}
 	defer os.RemoveAll(workDir)
 
+	// Normalize the architecture by calling ParseArchitecture.  This is
+	// something subtle that `apko` gets for free because it only accepts yaml
+	// and the yaml parsing normalizes things.
+	for i, arch := range ic.Archs {
+		ic.Archs[i] = apkotypes.ParseArchitecture(arch.String())
+	}
+
 	eg := errgroup.Group{}
 	archs := make([]resolved, len(ic.Archs))
 	for i, arch := range ic.Archs {


### PR DESCRIPTION
I tried running with `-race` and some tests still fail due to stuff in `go-apk`'s memfs.

This at least should fix the concurrent map writes, and another easy one I found running with `-race`.

Fixes #102 