### PR TITLE
Quiet the noise to allow reproducing builds from attestations.

### DIFF
--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -44,6 +44,7 @@ Read-Only:
 - `paths` (List of Object) (see [below for nested schema](#nestedobjatt--config--paths))
 - `stop-signal` (String)
 - `vcs-url` (String)
+- `volumes` (List of String)
 - `work-dir` (String)
 
 <a id="nestedobjatt--config--accounts"></a>

--- a/docs/data-sources/tags.md
+++ b/docs/data-sources/tags.md
@@ -43,6 +43,7 @@ Required:
 - `paths` (List of Object) (see [below for nested schema](#nestedobjatt--config--paths))
 - `stop-signal` (String)
 - `vcs-url` (String)
+- `volumes` (List of String)
 - `work-dir` (String)
 
 <a id="nestedobjatt--config--accounts"></a>

--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -85,6 +85,7 @@ Required:
 - `paths` (List of Object) (see [below for nested schema](#nestedobjatt--config--paths))
 - `stop-signal` (String)
 - `vcs-url` (String)
+- `volumes` (List of String)
 - `work-dir` (String)
 
 <a id="nestedobjatt--config--accounts"></a>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chainguard-dev/terraform-provider-apko
 go 1.19
 
 require (
-	chainguard.dev/apko v0.8.1-0.20230614194955-dc7ac85e1ac6
+	chainguard.dev/apko v0.8.1-0.20230624215248-a751f0e540e2
 	github.com/chainguard-dev/terraform-provider-oci v0.0.4
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.15.2
@@ -35,7 +35,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
-	github.com/chainguard-dev/go-apk v0.0.0-20230623221358-f867b780f14b // indirect
+	github.com/chainguard-dev/go-apk v0.0.0-20230624211543-feec2b17ac2c // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-chainguard.dev/apko v0.8.1-0.20230614194955-dc7ac85e1ac6 h1:pD9UiXyI261UjlPZLb8eqNb2+nHFxB2P+ynA4D0Q020=
-chainguard.dev/apko v0.8.1-0.20230614194955-dc7ac85e1ac6/go.mod h1:yniNL9VLVS19ZbIb9BBfI7kZQcRq1mHRzgdQuMMBqm0=
+chainguard.dev/apko v0.8.1-0.20230624215248-a751f0e540e2 h1:McZSAy+ErFMeLXOfCvgUkCSX9eJnNfLwdrqc2sSE3Xg=
+chainguard.dev/apko v0.8.1-0.20230624215248-a751f0e540e2/go.mod h1:ZtH/hF+7MVAzLyHMg+JmguNxGtk5DjMmtc0lw+4gWbs=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go/compute v1.19.1 h1:am86mquDUgjGNWxiGn+5PGLbmgiWXlE/yNWpIpNvuXY=
 cloud.google.com/go/compute v1.19.1/go.mod h1:6ylj3a05WF8leseCdIf77NK0g1ey+nj5IKd5/kvShxE=
@@ -48,10 +48,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
-github.com/chainguard-dev/go-apk v0.0.0-20230615021040-3632f56a6092 h1:x/KGwBpjVt+c4Kx00iL/s1fSoZvoefHwdmeAVIFmqYY=
-github.com/chainguard-dev/go-apk v0.0.0-20230615021040-3632f56a6092/go.mod h1:KBJLhDSM8/TcjL+N0y0pFCos35KqkIMOytkFyw+aJSQ=
-github.com/chainguard-dev/go-apk v0.0.0-20230623221358-f867b780f14b h1:OM8bGocVHI63Dn2o1HOTkdNBxB16+bloOrmBUodfcHc=
-github.com/chainguard-dev/go-apk v0.0.0-20230623221358-f867b780f14b/go.mod h1:koN42sGqNZ9A37tc2/yFVKPpT9c5nDIcOjjxG0AWMls=
+github.com/chainguard-dev/go-apk v0.0.0-20230624211543-feec2b17ac2c h1:VHivcT15SPM1LIfluh9A4X2mNUj3zT/YvZ7qnmRLJ+I=
+github.com/chainguard-dev/go-apk v0.0.0-20230624211543-feec2b17ac2c/go.mod h1:koN42sGqNZ9A37tc2/yFVKPpT9c5nDIcOjjxG0AWMls=
 github.com/chainguard-dev/terraform-provider-oci v0.0.4 h1:BgGdE7eT3z1dEvpcNld9HiUyIF4EUMW51e6YQE0Kay8=
 github.com/chainguard-dev/terraform-provider-oci v0.0.4/go.mod h1:sGjXlGpddLYEZx9i8dkxiEanQL0hLAiEaddsxj3gaoc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	"chainguard.dev/apko/pkg/build"
@@ -28,7 +29,22 @@ import (
 )
 
 func fromImageData(ic types.ImageConfiguration, popts ProviderOpts, wd string) (*build.Context, error) {
-	ic.Contents.Packages = sets.List(sets.New(ic.Contents.Packages...).Insert(popts.packages...))
+	// Deduplicate any of the extra packages against their potentially resolved
+	// form in the actual image list.
+	pkgs := sets.New(ic.Contents.Packages...)
+	extraPkgs := sets.New(popts.packages...)
+	for _, pkg := range sets.List(pkgs) {
+		name := pkg
+		// The function we want from go-apk is private, but these are all the
+		// special characters that delimit the package name from the cosntraint
+		// so lop off the package name and stick the rest of the constraint into
+		// the versions map.
+		if idx := strings.IndexAny(pkg, "=<>~"); idx >= 0 {
+			name = pkg[:idx]
+		}
+		extraPkgs.Delete(name)
+	}
+	ic.Contents.Packages = sets.List(pkgs.Union(extraPkgs))
 
 	// Normalize the architecture by calling ParseArchitecture.  This is
 	// something sublte that `apko` gets for free because it only accepts yaml
@@ -125,7 +141,6 @@ func doBuild(ctx context.Context, data BuildResourceModel, ropts []remote.Option
 			if bc.Options.SourceDateEpoch, err = bc.GetBuildDateEpoch(); err != nil {
 				return fmt.Errorf("failed to determine build date epoch: %w", err)
 			}
-			bc.Options.SourceDateEpoch = bc.Options.SourceDateEpoch.UTC()
 			// Adjust the index's builder to track the most recent BDE.
 			if bc.Options.SourceDateEpoch.After(obc.Options.SourceDateEpoch) {
 				obc.Options.SourceDateEpoch = bc.Options.SourceDateEpoch
@@ -194,7 +209,15 @@ func doBuild(ctx context.Context, data BuildResourceModel, ropts []remote.Option
 		}
 	}
 
-	idx := signed.ImageIndex(mutate.IndexMediaType(empty.Index, ggcrtypes.OCIImageIndex))
+	idx := signed.ImageIndex(
+		mutate.IndexMediaType(
+			mutate.Annotations(
+				empty.Index,
+				ic.Annotations,
+			).(v1.ImageIndex),
+			ggcrtypes.OCIImageIndex,
+		),
+	)
 	archs := make([]types.Architecture, 0, len(imgs))
 	for arch := range imgs {
 		archs = append(archs, arch)

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -36,7 +36,7 @@ func fromImageData(ic types.ImageConfiguration, popts ProviderOpts, wd string) (
 	for _, pkg := range sets.List(pkgs) {
 		name := pkg
 		// The function we want from go-apk is private, but these are all the
-		// special characters that delimit the package name from the cosntraint
+		// special characters that delimit the package name from the constraint
 		// so lop off the package name and stick the rest of the constraint into
 		// the versions map.
 		if idx := strings.IndexAny(pkg, "=<>~"); idx >= 0 {

--- a/internal/provider/resource_build_test.go
+++ b/internal/provider/resource_build_test.go
@@ -224,7 +224,7 @@ resource "apko_build" "foo" {
 				resource.TestCheckResourceAttr("apko_build.foo", "repo", repostr),
 				resource.TestCheckResourceAttr("apko_build.foo", "image_ref",
 					// With pinned packages we should always get this digest.
-					repo.Digest("sha256:334f171474bcc4fb81595489998c077d2916514d3296af8c9952a242f9a0d9d3").String()),
+					repo.Digest("sha256:dc8d5ec88c361751fa0255b191e6dae9f78917d9da8257645d5141ef5eb7928a").String()),
 
 				// Check that the build's amd64 predicate exists, the digest
 				// matches, and the creation timestamp is what we expect.
@@ -293,7 +293,7 @@ resource "apko_build" "foo" {
 				resource.TestCheckResourceAttr("apko_build.foo", "repo", repostr),
 				resource.TestCheckResourceAttr("apko_build.foo", "image_ref",
 					// With pinned packages we should always get this digest.
-					repo.Digest("sha256:592a4628161006424a3c6a2598b5e6b590eb96690a9e710cd156065e9316b81d").String()),
+					repo.Digest("sha256:a6d3b300b0248216300128c5252309ce2617cdbdd23c0d358027f7541fc84ede").String()),
 
 				// Check that the build's amd64 predicate exists, the digest
 				// matches, and the creation timestamp is what we expect.


### PR DESCRIPTION
These changes allow builds from `apko_build` to be reproduced by feeding an attestation of the `apko_config` through `apko publish`.
