### PR TITLE
Make failure to unify a specified package an error.

### DIFF
--- a/internal/provider/config_data_source_test.go
+++ b/internal/provider/config_data_source_test.go
@@ -408,7 +408,10 @@ func TestUnify(t *testing.T) {
 			"foo=1.2.3",
 		},
 		wantDiag: []diag.Diagnostic{
-			diag.NewWarningDiagnostic("unable to lock certain packages", "[bar]"),
+			diag.NewErrorDiagnostic(
+				`Unable to lock package "bar" to a consistent version`,
+				"2.4.6-r0 (amd64), 2.4.6-r1 (arm64)",
+			),
 		},
 	}, {
 		name:      "mismatched direct dependency (with constraint)",
@@ -439,7 +442,10 @@ func TestUnify(t *testing.T) {
 			"foo=1.2.3",
 		},
 		wantDiag: []diag.Diagnostic{
-			diag.NewWarningDiagnostic("unable to lock certain packages", "[bar]"),
+			diag.NewErrorDiagnostic(
+				`Unable to lock package "bar" to a consistent version`,
+				"2.4.6-r0 (amd64), 2.4.6-r1 (arm64)",
+			),
 		},
 	}, {
 		name:      "single-architecture resolved dependency",


### PR DESCRIPTION
Currently when we are performing package builds, we will be unable to lock a package version across architectures and we surface a mediocre warning, and the not-fully-locked configuration creates errors downstream when we try to create things like SLSA attestations or extract version tags because things are not fully resolved.

By promoting this to an error, we make things fail earlier and with a (now much) clearer error message.