### PR TITLE
parse YAML strictly, failing on unknown fields

### DIFF
--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -46,13 +46,12 @@ jobs:
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-    - uses: actions/setup-go@v4
-      with:
-        go-version-file: 'go.mod'
-
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       with:
         path: tf-apko
+    - uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
 
     - working-directory: tf-apko
       run: go build .

--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -51,7 +51,7 @@ jobs:
         path: tf-apko
     - uses: actions/setup-go@v4
       with:
-        go-version-file: 'go.mod'
+        go-version-file: 'tf-apko/go.mod'
 
     - working-directory: tf-apko
       run: go build .

--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version-file: 'go.mod'
 
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version-file: 'go.mod'
     - run: go generate ./...
     - name: git diff
       run: |
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version-file: 'go.mod'
 
     - uses: hashicorp/setup-terraform@v2
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/chainguard-dev/terraform-provider-apko
 
-go 1.20
+go 1.21
+
+toolchain go1.21.0
 
 require (
 	chainguard.dev/apko v0.10.1-0.20230906171757-7c910a4b75ca

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -113,7 +113,7 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	var ic apkotypes.ImageConfiguration
-	if err := yaml.Unmarshal([]byte(data.ConfigContents.ValueString()), &ic); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(data.ConfigContents.ValueString()), &ic); err != nil {
 		resp.Diagnostics.AddError("Unable to parse apko configuration", err.Error())
 		return
 	}

--- a/internal/provider/config_data_source_test.go
+++ b/internal/provider/config_data_source_test.go
@@ -488,3 +488,23 @@ func TestUnify(t *testing.T) {
 		})
 	}
 }
+
+func TestAccDataSourceConfig_Invalid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: `
+data "apko_config" "this" {
+  config_contents = <<EOF
+contents:
+  repositories:
+  - ./packages
+
+unknown-field: 'blah'
+EOF
+}`,
+			ExpectError: regexp.MustCompile("field unknown-field not found in type types.ImageConfiguration"),
+		}},
+	})
+}


### PR DESCRIPTION
There are some cases in the images repo, which will now result in an error:

```
│ Error: Unable to parse apko configuration
│ 
│   with module.dotnet.module.sdk-config.data.apko_config.this,
│   on images/dotnet/configs/sdk/main.tf line 12, in data "apko_config" "this":
│   12: data "apko_config" "this" {
│ 
│ yaml: unmarshal errors:
│   line 14: field recursive not found in type types.ImageAccounts
```

```
git grep "^  recursive:" | wc -l
      41
```

There may be other cases where we're doing this.