### PR TITLE
export reflect package, handle recursive types

### DIFF
--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -14,6 +14,7 @@ import (
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/tarfs"
+	"github.com/chainguard-dev/terraform-provider-apko/reflect"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	coci "github.com/sigstore/cosign/v2/pkg/oci"
@@ -86,7 +87,7 @@ func doBuild(ctx context.Context, data BuildResourceModel) (v1.Hash, coci.Signed
 	defer os.RemoveAll(tempDir)
 
 	var ic types.ImageConfiguration
-	if diags := assignValue(data.Config, &ic); diags.HasError() {
+	if diags := reflect.AssignValue(data.Config, &ic); diags.HasError() {
 		return v1.Hash{}, nil, nil, fmt.Errorf("assigning value: %v", diags.Errors())
 	}
 

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"reflect"
+	stdreflect "reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -13,6 +13,7 @@ import (
 	"chainguard.dev/apko/pkg/build"
 	apkotypes "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/tarfs"
+	"github.com/chainguard-dev/terraform-provider-apko/reflect"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -49,7 +50,7 @@ type ConfigDataSourceModel struct {
 var imageConfigurationSchema basetypes.ObjectType
 
 func init() {
-	sch, err := generateType(apkotypes.ImageConfiguration{})
+	sch, err := reflect.GenerateType(apkotypes.ImageConfiguration{})
 	if err != nil {
 		panic(err)
 	}
@@ -158,7 +159,7 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 	ic.Contents.Packages = pl
 
-	ov, diags := generateValue(ic)
+	ov, diags := reflect.GenerateValue(ic)
 	resp.Diagnostics = append(resp.Diagnostics, diags...)
 	if diags.HasError() {
 		return
@@ -274,7 +275,7 @@ func unify(originals []string, inputs []resolved) ([]string, diag.Diagnostics) {
 		provided: inputs[0].provided,
 	}
 	for _, next := range inputs[1:] {
-		if reflect.DeepEqual(acc.versions, next.versions) && reflect.DeepEqual(acc.provided, next.provided) {
+		if stdreflect.DeepEqual(acc.versions, next.versions) && stdreflect.DeepEqual(acc.provided, next.provided) {
 			// If the package set's versions and provided packages match, then we're done.
 			continue
 		}

--- a/internal/provider/tags_data_source.go
+++ b/internal/provider/tags_data_source.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	apkotypes "chainguard.dev/apko/pkg/build/types"
+	"github.com/chainguard-dev/terraform-provider-apko/reflect"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -97,7 +98,7 @@ func (d *TagsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	var ic apkotypes.ImageConfiguration
-	if diags := assignValue(data.Config, &ic); diags.HasError() {
+	if diags := reflect.AssignValue(data.Config, &ic); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -96,13 +96,13 @@ func GenerateValue(v any) (attr.Value, diag.Diagnostics) {
 var valueInProgress = sets.NewString()
 
 func generateValueReflect(path string, v reflect.Value) (out attr.Value, diagout diag.Diagnostics) {
-	if inProgress.Has(v.String()) {
+	if valueInProgress.Has(v.String()) {
 		log.Println("detected recursive type:", path)
 		// If we're already trying to figure out this value, then we're in a recursive loop. Avoid this by just returning an empty object.
 		return basetypes.NewObjectValue(nil, nil)
 	}
-	inProgress.Insert(v.String())
-	defer func() { inProgress.Delete(v.String()) }()
+	valueInProgress.Insert(v.String())
+	defer func() { valueInProgress.Delete(v.String()) }()
 
 	t := v.Type()
 	switch t.Kind() {

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -28,7 +28,7 @@ func generateTypeReflect(path string, inProgress sets.Set[string], t reflect.Typ
 	case reflect.Float32, reflect.Float64:
 		return basetypes.Float64Type{}, nil
 	case reflect.Ptr:
-		return generateTypeReflect("*"+path, inProgress, t.Elem())
+		return generateTypeReflect("*"+path, inProgress, reflect.New(t.Elem()).Type())
 
 	case reflect.Array, reflect.Slice:
 		st, err := generateTypeReflect(path+"[]", inProgress, t.Elem())

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -11,7 +11,12 @@ import (
 )
 
 type recursive struct {
-	Recursive []recursive
+	Foo   string
+	Slice []recursive
+	Map   map[string]recursive
+	// Go doesn't support these recursive types.
+	//Array [3]recursive
+	//Struct recursive
 }
 
 func TestGenerateType(t *testing.T) {
@@ -69,6 +74,7 @@ func TestGenerateType(t *testing.T) {
 				Skipped string `yaml:"-"`
 				Bar     []string
 			}
+			Pointer *string `yaml:"ptr"`
 		}{},
 		want: basetypes.ObjectType{
 			AttrTypes: map[string]attr.Type{
@@ -82,6 +88,7 @@ func TestGenerateType(t *testing.T) {
 						},
 					},
 				},
+				"ptr": basetypes.StringType{},
 			},
 		},
 	}, {
@@ -98,7 +105,13 @@ func TestGenerateType(t *testing.T) {
 				"outer": basetypes.ListType{
 					ElemType: basetypes.ObjectType{
 						AttrTypes: map[string]attr.Type{
-							"recursive": basetypes.ObjectType{},
+							"foo": basetypes.StringType{},
+							"slice": basetypes.ListType{
+								ElemType: basetypes.ObjectType{},
+							},
+							"map": basetypes.MapType{
+								ElemType: basetypes.ObjectType{},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
_Putting in draft while I iterate on the melange side to make sure this works as intended._

The reflect magic could be useful to other TF providers, so this moves it out of `internal`.

In playing with this for tf-melange (bad idea maybe TBD) I found it fell into an infinite loop if it was asked to handle a recursive type (e.g., melange's [`Pipeline`](https://pkg.go.dev/chainguard.dev/melange/pkg/config#Pipeline) which can recursively define sub-pipelines).

To handle this, if we find a recursive type we just report it as an empty object and get on with our lives.

To help debug this I added more logging about this case, which is only really surfaced if you `go run ./` the provider directly, and in tests. But it was really helpful to fix this, so I kept it. There's also a basic test for `GenerateType` with a recursive type.