### PR TITLE
support writing pre- and post-resolved configs to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ website/vendor
 *.winfile eol=crlf
 
 terraform-provider-apko
+
+# Test output when using TF_APKO_OUT_DIR
+*.apko.json


### PR DESCRIPTION
```
TF_APKO_OUT_DIR=$(pwd) TF_ACC=1 go test ./internal/provider/... -count=1
```

<details>
  <summary>10df20.pre.apko.json</summary>

```
{
  "contents": {
    "repositories": [
      "https://packages.wolfi.dev/os"
    ],
    "keyring": [
      "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
    ],
    "packages": [
      "ca-certificates-bundle",
      "tzdata",
      "wolfi-baselayout"
    ]
  },
  "entrypoint": {},
  "accounts": {
    "run-as": "65532",
    "users": [
      {
        "username": "nonroot",
        "uid": 65532,
        "gid": 65532
      }
    ],
    "groups": [
      {
        "groupname": "nonroot",
        "gid": 65532
      }
    ]
  },
  "archs": [
    "amd64",
    "arm64"
  ],
  "os-release": {}
}
```
</details>

<details>
  <summary>10df20.post.apko.json</summary>

```
{
  "contents": {
    "repositories": [
      "https://packages.wolfi.dev/os"
    ],
    "keyring": [
      "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
    ],
    "packages": [
      "ca-certificates-bundle=20230506-r1",
      "tzdata=2023c-r1",
      "wolfi-baselayout=20230201-r7"
    ]
  },
  "entrypoint": {},
  "accounts": {
    "run-as": "65532",
    "users": [
      {
        "username": "nonroot",
        "uid": 65532,
        "gid": 65532
      }
    ],
    "groups": [
      {
        "groupname": "nonroot",
        "gid": 65532
      }
    ]
  },
  "archs": [
    "amd64",
    "arm64"
  ],
  "os-release": {}
}
```

</details>