### PR TITLE
Audit the permissions on workflows.

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
+      id-token: write # Used for gitsign
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,12 @@ on:
   push:
     tags:
       - 'v*'
+
 jobs:
   goreleaser:
+    permissions:
+      contents: write # To publish the release.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This reduces the digestabot permissions to reflect the use of a PAT, and adds explicit permissions to the release workflow.