### PR TITLE
apko_tags: handle provides better

### DIFF
--- a/internal/provider/tags_data_source.go
+++ b/internal/provider/tags_data_source.go
@@ -117,8 +117,13 @@ func (d *TagsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	} else {
 		for pkg := range pkgs {
 			if strings.HasPrefix(pkg, data.TargetPackage.ValueString()+"-") {
+				if found != "" {
+					resp.Diagnostics.AddError("Multiple packages match", fmt.Sprintf("Multiple packages match: %s and %s", found, pkg))
+					return
+				}
+
 				found = pkg
-				break
+				// Don't stop; keep looking in case there are multiple matches!
 			}
 		}
 	}

--- a/internal/provider/tags_data_source_test.go
+++ b/internal/provider/tags_data_source_test.go
@@ -28,6 +28,7 @@ contents:
   - ca-certificates-bundle=20230506-r0
   - glibc-locale-posix=2.37-r6
   - ko=0.13.0-r3
+  - nodejs=21.7.3-r1 # Initial request will be satisfied by 'provides'
 EOF
   extra_packages = ["tzdata=2023c-r0"]
 }
@@ -55,6 +56,16 @@ data "apko_tags" "tzdata" {
 data "apko_tags" "ko" {
   config         = data.apko_config.this.config
   target_package = "ko"
+}
+
+data "apko_tags" "nodejs" {
+  config         = data.apko_config.this.config
+  target_package = "nodejs" # Tags can be inferred from 'provides'
+}
+
+data "apko_tags" "nodejs-21" {
+  config         = data.apko_config.this.config
+  target_package = "nodejs-21"
 }
 `,
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -85,6 +96,22 @@ data "apko_tags" "ko" {
 				resource.TestCheckResourceAttr("data.apko_tags.ko", "tags.2", "0.13.0"),
 				resource.TestCheckResourceAttr("data.apko_tags.ko", "tags.3", "0.13.0-r3"),
 				resource.TestCheckResourceAttr("data.apko_tags.ko", "id", "0,0.13,0.13.0,0.13.0-r3"),
+
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.#", "4"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.0", "21"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.1", "21.7"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.2", "21.7.3"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.3", "21.7.3-r1"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "id", "21,21.7,21.7.3,21.7.3-r1"),
+
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.#", "4"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.0", "21"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.1", "21.7"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.2", "21.7.3"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.3", "21.7.3-r1"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "id", "21,21.7,21.7.3,21.7.3-r1"),
+
+				//21.7.3-r1.apk
 			),
 		}},
 	})
@@ -112,6 +139,7 @@ contents:
   - ca-certificates-bundle=20230506-r0
   - glibc-locale-posix=2.37-r6
   - ko=0.13.0-r3
+  - nodejs=21.7.3-r1
 EOF
   extra_packages = ["tzdata=2023c-r0"]
 }


### PR DESCRIPTION
Today sometimes configs request some package, say, `nodejs`, which gets provided by a package named `nodejs-21`. When it comes time to get the tags for this config, we can't pass `nodejs` today because the resulting config has no package with that name. And callers don't necessarily know it's called `nodejs-21`, or else they would have requested that.

This makes `apko_tags` aware of this scenario and slightly less dumb, and if it can't find a package named `nodejs`, will look for a package named `nodejs-*` and assume that's the desired package.