### PR TITLE
Improve unable to find package error message

### DIFF
--- a/internal/provider/tags_data_source.go
+++ b/internal/provider/tags_data_source.go
@@ -114,7 +114,7 @@ func (d *TagsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		}
 	}
 	if !found {
-		resp.Diagnostics.AddError("Unable to find package", fmt.Sprintf("Unable to find package: %s", data.TargetPackage.ValueString()))
+        resp.Diagnostics.AddError(fmt.Sprintf("Unable to find package: %s...", data.TargetPackage.ValueString()), fmt.Sprintf("...in package list:\n\t%s", strings.Join(ic.Contents.Packages, "\n\t")))
 		return
 	}
 


### PR DESCRIPTION
From

```
╷
│ Error: Unable to find package
│
│   with module.keda.module.versioned["keda-2.13"].data.apko_tags.tags[0],
│   on tflib/publisher/main.tf line 189, in data "apko_tags" "tags":
│  189: data "apko_tags" "tags" {
│
│ Unable to find package: keda-2.13
╵
```

To

```
╷
│ Error: Unable to find package: keda-2.13...
│
│   with module.keda.module.versioned["keda-2.13"].data.apko_tags.tags[0],
│   on tflib/publisher/main.tf line 189, in data "apko_tags" "tags":
│  189: data "apko_tags" "tags" {
│
│ ...in package list:
│       busybox=1.36.1-r8
│       ca-certificates-bundle=20240315-r1
│       chainguard-baselayout=20230214-r6
│       glibc=2.39-r3
│       glibc-locale-posix=2.39-r3
│       keda-2.14=2.14.0-r0
│       keda-2.14-compat=2.14.0-r0
│       ld-linux=2.39-r3
│       libcrypt1=2.39-r3
│       libxcrypt=4.4.36-r5
│       tzdata=2024a-r1
│       wolfi-baselayout=20230201-r8
╵
```