### PR TITLE
bump apko to 0.14.6

### DIFF
--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -71,6 +71,7 @@ Read-Only:
 Read-Only:
 
 - `gid` (Number)
+- `homedir` (String)
 - `shell` (String)
 - `uid` (Number)
 - `username` (String)

--- a/docs/data-sources/tags.md
+++ b/docs/data-sources/tags.md
@@ -70,6 +70,7 @@ Required:
 Required:
 
 - `gid` (Number)
+- `homedir` (String)
 - `shell` (String)
 - `uid` (Number)
 - `username` (String)

--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -112,6 +112,7 @@ Required:
 Required:
 
 - `gid` (Number)
+- `homedir` (String)
 - `shell` (String)
 - `uid` (Number)
 - `username` (String)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/chainguard-dev/terraform-provider-apko
 
-go 1.22.0
+go 1.22.3
 
 require (
-	chainguard.dev/apko v0.14.3
+	chainguard.dev/apko v0.14.6
 	github.com/chainguard-dev/clog v1.3.1
 	github.com/chainguard-dev/terraform-provider-oci v0.0.13
 	github.com/google/go-cmp v0.6.0
@@ -37,7 +37,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
-	github.com/chainguard-dev/go-apk v0.0.0-20240514202343-05db79c0242f // indirect
+	github.com/chainguard-dev/go-apk v0.0.0-20240530214935-2ff9aee8385a // indirect
 	github.com/cloudflare/circl v1.3.8 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -84,7 +84,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.6 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hc-install v0.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-chainguard.dev/apko v0.14.3 h1:5saMBQSqCyAQawYSenfzxBlqjbAVQXga63deCQot5Bk=
-chainguard.dev/apko v0.14.3/go.mod h1:EIXq/pvqHojOhZdlwtzlsNZfx2hJaqjFmdv0NSzmjbc=
+chainguard.dev/apko v0.14.6 h1:w3NDIF+UhWMTGSMuWi35WLegsJrRBZ+nDWGcv6xbrE0=
+chainguard.dev/apko v0.14.6/go.mod h1:0OxxhLPudWqL5doT4tmA9u7JphFj4gn66Iczwp2zJJw=
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
@@ -51,8 +51,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chainguard-dev/clog v1.3.1 h1:CDNCty5WKQhJzoOPubk0GdXt+bPQyargmfClqebrpaQ=
 github.com/chainguard-dev/clog v1.3.1/go.mod h1:cV516KZWqYc/phZsCNwF36u/KMGS+Gj5Uqeb8Hlp95Y=
-github.com/chainguard-dev/go-apk v0.0.0-20240514202343-05db79c0242f h1:TrHbtcSJcXZF9Uo18JNjVV644p4sMpsEty6yyjO2INU=
-github.com/chainguard-dev/go-apk v0.0.0-20240514202343-05db79c0242f/go.mod h1:2tpUKTTAWl5dJmtvOwvSUjNRFp3oc7qOPqSW8I+XLDM=
+github.com/chainguard-dev/go-apk v0.0.0-20240530214935-2ff9aee8385a h1:E8EgiRgZsmq1Twz6H2gyyzDB0OxHfZ+h3g8R9BimdAU=
+github.com/chainguard-dev/go-apk v0.0.0-20240530214935-2ff9aee8385a/go.mod h1:4UVB5GXk5yVOVwe3QPdmMLMVTpYbvzygjXlRrJxJPMc=
 github.com/chainguard-dev/terraform-provider-oci v0.0.13 h1:s3KXwV/+lDJIFWLzpUnjzMy796ipllDReBn3IR2gpkk=
 github.com/chainguard-dev/terraform-provider-oci v0.0.13/go.mod h1:WPxkSDM5nfVbSM1GQy6FtEyuGzde2wwz9ES6F7FMVOQ=
 github.com/cloudflare/circl v1.3.8 h1:j+V8jJt09PoeMFIu2uh5JUyEaIHTXVOHslFoLNAKqwI=
@@ -181,8 +181,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.1 h1:P7MR2UP6gNKGPp+y7EZw2kOiq4IR9WiqLvp0XOsVdwI=
 github.com/hashicorp/go-plugin v1.6.1/go.mod h1:XPHFku2tFo3o3QKFgSYo+cghcUhw1NA1hZyMK0PWAw0=
-github.com/hashicorp/go-retryablehttp v0.7.6 h1:TwRYfx2z2C4cLbXmT8I5PgP/xmuqASDyiVuGYfs9GZM=
-github.com/hashicorp/go-retryablehttp v0.7.6/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=


### PR DESCRIPTION
dependabot is still on 1.22.2 so the auto update for this failed

```
go: loading module retractions for chainguard.dev/apko@v0.1.1: module chainguard.dev/apko@v0.14.5 requires go >= 1.22.3 (running go 1.22.2; GOTOOLCHAIN=local+auto)
```

https://github.com/chainguard-dev/apko/releases/tag/v0.14.6