### PR TITLE
WIP: support remote image resolver and builder

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,4 @@ provider "apko" {}
 - `extra_keyring` (List of String) Additional keys to use for package verification
 - `extra_packages` (List of String) Additional packages to install
 - `extra_repositories` (List of String) Additional repositories to search for packages
+- `remote_builder` (String) Remote builder to use (EXPERIMENTAL)


### PR DESCRIPTION
This allows us to configure a provider-wide remote builder URL, which will be responsible for resolving configs, and building resolved configs.