### PR TITLE
If we fail to lock, include the config

### DIFF
--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -77,7 +77,7 @@ jobs:
     - working-directory: images
       env:
         TF_VAR_target_repository: ttl.sh/tf-apko
-        APKO_IMAGE: ghcr.io/wolfi-dev/sdk:latest@sha256:91b6f2536990b5be900e35d343c08c22b3918123bb69b6d12968d4fd77b34363
+        APKO_IMAGE: ghcr.io/wolfi-dev/sdk:latest@sha256:7f344964b35250460ead198fa58c6935ebd6c956fbc9b520fdde267f646aebac
       run: |
         terraform init
 


### PR DESCRIPTION
It's nearly impossible to get at the config that failed if we fail to lock (because we won't have a plan to inspect), so we'll include the input config in the diagnostic details to make this at least possible.