### PR TITLE
add `plan_offline` provider option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,4 @@ provider "apko" {}
 - `extra_keyring` (List of String) Additional keys to use for package verification
 - `extra_packages` (List of String) Additional packages to install
 - `extra_repositories` (List of String) Additional repositories to search for packages
+- `plan_offline` (Boolean) Whether to plan offline

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -270,7 +270,7 @@ func (d *ConfigDataSource) resolvePackageList(ctx context.Context, ic apkotypes.
 	}
 
 	pls, missingByArch, err := build.LockImageConfiguration(ctx, *ic2,
-		build.WithCache("", false, d.popts.cache),
+		build.WithCache("", d.popts.planOffline, d.popts.cache),
 		build.WithSBOMFormats([]string{"spdx"}),
 		build.WithExtraKeys(d.popts.keyring),
 		build.WithExtraBuildRepos(d.popts.buildRespositories),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,6 +31,7 @@ type ProviderModel struct {
 	ExtraKeyring       []string          `tfsdk:"extra_keyring"`
 	DefaultAnnotations map[string]string `tfsdk:"default_annotations"`
 	DefaultArchs       []string          `tfsdk:"default_archs"`
+	PlanOffline        *bool             `tfsdk:"plan_offline"`
 }
 
 type ProviderOpts struct {
@@ -38,6 +39,7 @@ type ProviderOpts struct {
 	anns                                                       map[string]string
 	cache                                                      *apk.Cache
 	ropts                                                      []remote.Option
+	planOffline                                                bool
 }
 
 func (p *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -77,6 +79,10 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 				Description: "Default architectures to build for",
 				Optional:    true,
 				ElementType: basetypes.StringType{},
+			},
+			"plan_offline": schema.BoolAttribute{
+				Description: "Whether to plan offline",
+				Optional:    true,
 			},
 		},
 	}
@@ -128,6 +134,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		archs:              append(p.archs, data.DefaultArchs...),
 		anns:               combineMaps(p.anns, data.DefaultAnnotations),
 		cache:              apk.NewCache(true),
+		planOffline:        data.PlanOffline != nil && *data.PlanOffline,
 		ropts:              ropts,
 	}
 

--- a/internal/provider/tags_data_source_test.go
+++ b/internal/provider/tags_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceTags(t *testing.T) {
 				repositories: []string{"https://packages.wolfi.dev/os"},
 				keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
 				archs:        []string{"x86_64", "aarch64"},
-				packages:     []string{"wolfi-baselayout=20230201-r0"},
+				packages:     []string{"wolfi-baselayout=20230201-r19"},
 			}),
 		},
 		Steps: []resource.TestStep{{
@@ -82,8 +82,8 @@ data "apko_tags" "nodejs-21" {
 
 				resource.TestCheckResourceAttr("data.apko_tags.wolfi-baselayout", "tags.#", "2"),
 				resource.TestCheckResourceAttr("data.apko_tags.wolfi-baselayout", "tags.0", "20230201"),
-				resource.TestCheckResourceAttr("data.apko_tags.wolfi-baselayout", "tags.1", "20230201-r0"),
-				resource.TestCheckResourceAttr("data.apko_tags.wolfi-baselayout", "id", "20230201,20230201-r0"),
+				resource.TestCheckResourceAttr("data.apko_tags.wolfi-baselayout", "tags.1", "20230201-r19"),
+				resource.TestCheckResourceAttr("data.apko_tags.wolfi-baselayout", "id", "20230201,20230201-r19"),
 
 				resource.TestCheckResourceAttr("data.apko_tags.tzdata", "tags.#", "2"),
 				resource.TestCheckResourceAttr("data.apko_tags.tzdata", "tags.0", "2023c"),
@@ -127,7 +127,7 @@ func TestAccDataSourceTags_Disabled(t *testing.T) {
 				repositories: []string{"https://packages.wolfi.dev/os"},
 				keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
 				archs:        []string{"x86_64", "aarch64"},
-				packages:     []string{"wolfi-baselayout=20230201-r0"},
+				packages:     []string{"wolfi-baselayout=20230201-r19"},
 			}),
 		},
 		Steps: []resource.TestStep{{


### PR DESCRIPTION
This plumbs an optional boolean through the provider to `apko_config` datasources, telling them not to fetch a new APKINDEX to solve, and instead require a locally-cached APKINDEX.

The intention with this is that we could pre-fetch an APKINDEX before sharding image builds, and avoid each shard fetching its own APKINDEX, which could introduce skew between package solutions on different shards.