### PR TITLE
Clean ups

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 1 * * *"
 
+permissions: {}
+
 jobs:
   image-update:
     name: Image digest update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,13 +3,16 @@ name: Lint
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -17,6 +20,6 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.63
+          version: v2.0

--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -9,32 +9,34 @@ concurrency:
   group: presubmit-build-${{ github.head_ref }}
   cancel-in-progress: true
 
-permissions:
-  # WARNING: This is mattmoor being a bit *too* clever.
-  # We want to be able to test the reproducibility of things via the upstream
-  # check-reproducibility test, which requires ambient credentials, but those
-  # are only available to pull requests under two circumstances:
-  #  1. The trigger is `pull_request_target`, and
-  #  2. The pull request is from a branch on the main repo.
-  # However, this doesn't cause things to fail when the pull request is from a
-  # fork, it will just make the tf-cosign rules NOPs and the
-  # check-repoducibility skip.
-  #
-  # But why not just use pull_request_target?
-  # This is because to pull in breaking changes to apko, we will need to update
-  # our apko Go dependency and the APKO_IMAGE (below) in the same PR, and the
-  # latter cannot be checked with the former if the workflow is
-  # pull_request_target.
-  #
-  # All of that said, dependabot and digestabot PRs come from branches on the
-  # main repo, so the net effect of this SHOULD be that we get an error
-  # presubmit when digestabot wants to pull in an update that is not
-  # reproducible with the version of the apko Go library we depend on.
-  id-token: write
+permissions: {}
 
 jobs:
   build-the-world:
     runs-on: ubuntu-latest
+
+    permissions:
+      # WARNING: This is mattmoor being a bit *too* clever.
+      # We want to be able to test the reproducibility of things via the upstream
+      # check-reproducibility test, which requires ambient credentials, but those
+      # are only available to pull requests under two circumstances:
+      #  1. The trigger is `pull_request_target`, and
+      #  2. The pull request is from a branch on the main repo.
+      # However, this doesn't cause things to fail when the pull request is from a
+      # fork, it will just make the tf-cosign rules NOPs and the
+      # check-repoducibility skip.
+      #
+      # But why not just use pull_request_target?
+      # This is because to pull in breaking changes to apko, we will need to update
+      # our apko Go dependency and the APKO_IMAGE (below) in the same PR, and the
+      # latter cannot be checked with the former if the workflow is
+      # pull_request_target.
+      #
+      # All of that said, dependabot and digestabot PRs come from branches on the
+      # main repo, so the net effect of this SHOULD be that we get an error
+      # presubmit when digestabot wants to pull in an update that is not
+      # reproducible with the version of the apko Go library we depend on.
+      id-token: write
 
     steps:
     # In some cases, we runs out of disk space during tests, so this hack frees up approx 10G.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,11 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   goreleaser:
+
     permissions:
       contents: write # To publish the release.
       id-token: write # To federate for the GPG key.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-        - '1.8.*'
         - '1.9.*'
         - '1.10.*'
+        - '1.11.*'
+
     permissions:
       contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,15 @@ on:
   push:
     branches: ['main']
 
+permissions: {}
+
 jobs:
   generate:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -33,6 +39,8 @@ jobs:
         - '1.8.*'
         - '1.9.*'
         - '1.10.*'
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,40 @@
----
-run:
-  timeout: 5m
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - durationcheck
     - errcheck
     - forcetypeassert
     - godot
-    - gofmt
-    - gosimple
     - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,8 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats:
+    - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:

--- a/main.go
+++ b/main.go
@@ -73,8 +73,8 @@ func (h tfhandler) Handle(ctx context.Context, r slog.Record) error {
 	return nil
 }
 
-func (_ tfhandler) Enabled(context.Context, slog.Level) bool { return true }
+func (tfhandler) Enabled(context.Context, slog.Level) bool { return true }
 func (h tfhandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return tfhandler{attrs: append(h.attrs, attrs...)}
 }
-func (_ tfhandler) WithGroup(name string) slog.Handler { panic("unimplemented") }
+func (tfhandler) WithGroup(name string) slog.Handler { panic("unimplemented") }


### PR DESCRIPTION
- update deprecated goreleaser field
- upgrade golangci-lint to v2
- clean up ci
- add terraform 1.11 and drop 1.8 for tests