### PR TITLE
Add provider-level layering support to tf-apko

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,16 @@ provider "apko" {}
 - `build_repositories` (List of String) Additional repositories to search for packages, only during apko build
 - `default_annotations` (Map of String) Default annotations to add
 - `default_archs` (List of String) Default architectures to build for
+- `default_layering` (Attributes) Default image layering configuration when not specified in the config (see [below for nested schema](#nestedatt--default_layering))
 - `extra_keyring` (List of String) Additional keys to use for package verification
 - `extra_packages` (List of String) Additional packages to install
 - `extra_repositories` (List of String) Additional repositories to search for packages
 - `plan_offline` (Boolean) Whether to plan offline
+
+<a id="nestedatt--default_layering"></a>
+### Nested Schema for `default_layering`
+
+Required:
+
+- `budget` (Number) Budget for the maximum number of layers that can be generated
+- `strategy` (String) Layering strategy, currently only 'origin' is supported

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	chainguard.dev/apko v0.27.0
+	chainguard.dev/apko v0.27.1
 	github.com/chainguard-dev/clog v1.7.0
 	github.com/chainguard-dev/terraform-provider-oci v0.0.20
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.20.4-0.20250225234217-098045d5e61f
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
@@ -157,6 +158,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/posener/complete v1.2.3 // indirect
@@ -178,6 +180,7 @@ require (
 	github.com/sigstore/timestamp-authority v1.2.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
@@ -188,7 +191,10 @@ require (
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.0.2 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
+	github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0 // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
+	github.com/u-root/u-root v0.14.0 // indirect
+	github.com/u-root/uio v0.0.0-20240209044354-b3d14b93376a // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 chainguard.dev/apko v0.27.0 h1:lADk1YWk0qUMKS70VjZp6GNFK5+6kAXREBnyVO5Q6Kw=
 chainguard.dev/apko v0.27.0/go.mod h1:MyEr+sYKtDaTuk0oGSFYL/WFe61iC4vOLnEy2pw8efw=
+chainguard.dev/apko v0.27.1 h1:+EVA7sii0404daFnH/hGwFDKAxWoj667T6n/ZdW6D38=
+chainguard.dev/apko v0.27.1/go.mod h1:MyEr+sYKtDaTuk0oGSFYL/WFe61iC4vOLnEy2pw8efw=
 chainguard.dev/go-grpc-kit v0.17.10 h1:uymMNUIBgbypeIurW25XaXvx3kbS0JpfKsJEMrS0abY=
 chainguard.dev/go-grpc-kit v0.17.10/go.mod h1:RPyCEjTxWAxrODH5V4vJOLy/gHRjEjVF9dzWN+LmIvo=
 chainguard.dev/sdk v0.1.32 h1:pZWN2irtvKMaAkgOpM3LRhuOrlpR3UGhg4F9LVWSyA8=
@@ -352,6 +354,8 @@ github.com/hashicorp/terraform-plugin-docs v0.21.0 h1:yoyA/Y719z9WdFJAhpUkI1jRbK
 github.com/hashicorp/terraform-plugin-docs v0.21.0/go.mod h1:J4Wott1J2XBKZPp/NkQv7LMShJYOcrqhQ2myXBcu64s=
 github.com/hashicorp/terraform-plugin-framework v1.14.1 h1:jaT1yvU/kEKEsxnbrn4ZHlgcxyIfjvZ41BLdlLk52fY=
 github.com/hashicorp/terraform-plugin-framework v1.14.1/go.mod h1:xNUKmvTs6ldbwTuId5euAtg37dTxuyj3LHS3uj7BHQ4=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0 h1:0uYQcqqgW3BMyyve07WJgpKorXST3zkpzvrOnf3mpbg=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0/go.mod h1:VwdfgE/5Zxm43flraNa0VjcvKQOGVrcO4X8peIri0T0=
 github.com/hashicorp/terraform-plugin-go v0.26.0 h1:cuIzCv4qwigug3OS7iKhpGAbZTiypAfFQmw8aE65O2M=
 github.com/hashicorp/terraform-plugin-go v0.26.0/go.mod h1:+CXjuLDiFgqR+GcrM5a2E2Kal5t5q2jb0E3D57tTdNY=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
@@ -482,6 +486,8 @@ github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoX
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
+github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
@@ -556,6 +562,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
@@ -591,8 +599,14 @@ github.com/tink-crypto/tink-go/v2 v2.3.0 h1:4/TA0lw0lA/iVKBL9f8R5eP7397bfc4antAM
 github.com/tink-crypto/tink-go/v2 v2.3.0/go.mod h1:kfPOtXIadHlekBTeBtJrHWqoGL+Fm3JQg0wtltPuxLU=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
+github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0 h1:hwIpbdjckSFqmZ6hod7WZgGR7tVVrSUzZrBfNZl7AOg=
+github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0/go.mod h1:DV83s9TfD0rgoKcqvDmM+aYdz6BXmTkquwd+bI/8tlo=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/u-root/u-root v0.14.0 h1:Ka4T10EEML7dQ5XDvO9c3MBN8z4nuSnGjcd1jmU2ivg=
+github.com/u-root/u-root v0.14.0/go.mod h1:hAyZorapJe4qzbLWlAkmSVCJGbfoU9Pu4jpJ1WMluqE=
+github.com/u-root/uio v0.0.0-20240209044354-b3d14b93376a h1:BH1SOPEvehD2kVrndDnGJiUF0TrBpNs+iyYocu6h0og=
+github.com/u-root/uio v0.0.0-20240209044354-b3d14b93376a/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -171,6 +171,16 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		}
 	}
 
+	// Apply provider-level layering configuration if none is specified in the image config
+	if ic.Layering == nil && d.popts.layering != nil {
+		// No layering specified in config, apply provider defaults
+		ic.Layering = &apkotypes.Layering{
+			Strategy: d.popts.layering.Strategy,
+			Budget:   d.popts.layering.Budget,
+		}
+	}
+	// When layering:{} is present, we preserve the empty object as-is
+
 	// Normalize the architectures we surface
 	for i, a := range ic.Archs {
 		ic.Archs[i] = apkotypes.ParseArchitecture(a.ToAPK())

--- a/internal/provider/layering_test.go
+++ b/internal/provider/layering_test.go
@@ -1,0 +1,302 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	ocitesting "github.com/chainguard-dev/terraform-provider-oci/testing"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestProviderLayeringDefaults tests that provider-level layering settings are applied
+// when no layering is specified at the resource level.
+func TestProviderLayeringDefaults(t *testing.T) {
+	repo, cleanup := ocitesting.SetupRepository(t, "test-provider-layering")
+	defer cleanup()
+
+	repoStr := repo.String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"apko": providerserver.NewProtocol6WithError(&Provider{
+				repositories:       []string{"https://packages.wolfi.dev/os"},
+				buildRespositories: []string{"./packages"},
+				keyring:            []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
+				archs:              []string{"x86_64"},
+				packages:           []string{"wolfi-baselayout"},
+				layering: &LayeringConfig{
+					Strategy: "origin",
+					Budget:   5, // Provider sets a budget of 5
+				},
+			}),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "apko_config" "provider_layering" {
+  config_contents = <<EOF
+contents:
+  packages:
+    - ca-certificates-bundle=20230506-r0
+    - glibc-locale-posix=2.37-r6
+    - tzdata=2023c-r0
+# No layering configuration specified - should use provider defaults
+EOF
+}
+
+output "layering_strategy" {
+  value = data.apko_config.provider_layering.config.layering.strategy
+}
+
+output "layering_budget" {
+  value = data.apko_config.provider_layering.config.layering.budget
+}
+
+resource "apko_build" "provider_layering" {
+  repo   = %q
+  config = data.apko_config.provider_layering.config
+}
+`, repoStr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("layering_strategy", "origin"),
+					resource.TestCheckOutput("layering_budget", "5"),
+					resource.TestCheckFunc(func(s *terraform.State) error {
+						// Get the image reference from terraform state
+						rs, ok := s.RootModule().Resources["apko_build.provider_layering"]
+						if !ok {
+							return fmt.Errorf("resource not found: apko_build.provider_layering")
+						}
+
+						imageRef := rs.Primary.Attributes["image_ref"]
+						if imageRef == "" {
+							return fmt.Errorf("no image_ref in resource state")
+						}
+
+						// Pull the image and check its layers
+						img, err := crane.Pull(imageRef)
+						if err != nil {
+							return fmt.Errorf("failed to pull image: %v", err)
+						}
+
+						manifest, err := img.Manifest()
+						if err != nil {
+							return fmt.Errorf("failed to get manifest: %v", err)
+						}
+
+						// We expect multiple layers because provider layering is set
+						// With 4 packages (3 from config + wolfi-baselayout) and a budget of 5,
+						// we should expect each package to get its own layer, plus the metadata layer
+						expectedLayerCount := 5 // 4 packages + 1 metadata layer
+
+						actualLayerCount := len(manifest.Layers)
+						if actualLayerCount != expectedLayerCount {
+							return fmt.Errorf("expected %d layers from provider-level layering with budget 5, got %d layers",
+								expectedLayerCount, actualLayerCount)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestResourceLayeringOverrides tests that resource-level layering settings override
+// the provider-level defaults.
+func TestResourceLayeringOverrides(t *testing.T) {
+	repo, cleanup := ocitesting.SetupRepository(t, "test-resource-layering")
+	defer cleanup()
+
+	repoStr := repo.String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"apko": providerserver.NewProtocol6WithError(&Provider{
+				repositories:       []string{"https://packages.wolfi.dev/os"},
+				buildRespositories: []string{"./packages"},
+				keyring:            []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
+				archs:              []string{"x86_64"},
+				packages:           []string{"wolfi-baselayout"},
+				layering: &LayeringConfig{
+					Strategy: "origin",
+					Budget:   1, // Provider sets a very low budget
+				},
+			}),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "apko_config" "resource_layering" {
+  config_contents = <<EOF
+contents:
+  packages:
+    - ca-certificates-bundle=20230506-r0
+    - glibc-locale-posix=2.37-r6
+    - tzdata=2023c-r0
+layering:
+  strategy: origin
+  budget: 10  # Resource explicitly sets a higher budget, should override provider
+EOF
+}
+
+output "resource_layering_strategy" {
+  value = data.apko_config.resource_layering.config.layering.strategy
+}
+
+output "resource_layering_budget" {
+  value = data.apko_config.resource_layering.config.layering.budget
+}
+
+resource "apko_build" "resource_layering" {
+  repo    = %q
+  config  = data.apko_config.resource_layering.config
+  configs = data.apko_config.resource_layering.configs
+}
+`, repoStr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("resource_layering_strategy", "origin"),
+					resource.TestCheckOutput("resource_layering_budget", "10"),
+					resource.TestCheckFunc(func(s *terraform.State) error {
+						// Get the image reference from terraform state
+						rs, ok := s.RootModule().Resources["apko_build.resource_layering"]
+						if !ok {
+							return fmt.Errorf("resource not found: apko_build.resource_layering")
+						}
+
+						imageRef := rs.Primary.Attributes["image_ref"]
+						if imageRef == "" {
+							return fmt.Errorf("no image_ref in resource state")
+						}
+
+						// Pull the image and check its layers
+						img, err := crane.Pull(imageRef)
+						if err != nil {
+							return fmt.Errorf("failed to pull image: %v", err)
+						}
+
+						manifest, err := img.Manifest()
+						if err != nil {
+							return fmt.Errorf("failed to get manifest: %v", err)
+						}
+
+						// With resource layering set to budget 10, we should get multiple layers.
+						// If the provider setting (budget 1) was being used instead, we'd only get 2 layers.
+						// With 4 packages (3 from config + wolfi-baselayout) and a budget of 10,
+						// we should expect each package to get its own layer, plus the metadata layer
+						expectedLayerCount := 5 // 4 packages + 1 metadata layer
+
+						actualLayerCount := len(manifest.Layers)
+						if actualLayerCount != expectedLayerCount {
+							return fmt.Errorf("expected %d layers from resource-level layering with budget 10, got %d layers",
+								expectedLayerCount, actualLayerCount)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestEmptyLayeringOverride tests that an empty layering block (layering: {})
+// at the resource level overrides the provider-level default_layering,
+// resulting in a single-layer image.
+func TestEmptyLayeringOverride(t *testing.T) {
+	repo, cleanup := ocitesting.SetupRepository(t, "test-empty-layering")
+	defer cleanup()
+
+	repoStr := repo.String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"apko": providerserver.NewProtocol6WithError(&Provider{
+				repositories:       []string{"https://packages.wolfi.dev/os"},
+				buildRespositories: []string{"./packages"},
+				keyring:            []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
+				archs:              []string{"x86_64"},
+				packages:           []string{"wolfi-baselayout"},
+				layering: &LayeringConfig{
+					Strategy: "origin",
+					Budget:   10, // Provider sets a high budget to ensure multiple layers by default
+				},
+			}),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "apko_config" "empty_layering" {
+  config_contents = <<EOF
+contents:
+  packages:
+    - ca-certificates-bundle=20230506-r0
+    - glibc-locale-posix=2.37-r6
+    - tzdata=2023c-r0
+layering: {}  # Empty layering block should override provider defaults
+EOF
+}
+
+output "empty_layering_strategy" {
+  value = try(data.apko_config.empty_layering.config.layering.strategy, "")
+}
+
+output "empty_layering_budget" {
+  value = try(data.apko_config.empty_layering.config.layering.budget, 0)
+}
+
+resource "apko_build" "empty_layering" {
+  repo   = %q
+  config = data.apko_config.empty_layering.config
+}
+`, repoStr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("empty_layering_strategy", ""),
+					resource.TestCheckOutput("empty_layering_budget", "0"),
+					resource.TestCheckFunc(func(s *terraform.State) error {
+						// Get the image reference from terraform state
+						rs, ok := s.RootModule().Resources["apko_build.empty_layering"]
+						if !ok {
+							return fmt.Errorf("resource not found: apko_build.empty_layering")
+						}
+
+						imageRef := rs.Primary.Attributes["image_ref"]
+						if imageRef == "" {
+							return fmt.Errorf("no image_ref in resource state")
+						}
+
+						// Pull the image and check its layers
+						img, err := crane.Pull(imageRef)
+						if err != nil {
+							return fmt.Errorf("failed to pull image: %v", err)
+						}
+
+						manifest, err := img.Manifest()
+						if err != nil {
+							return fmt.Errorf("failed to get manifest: %v", err)
+						}
+
+						// With an empty layering block, the provider defaults should be ignored
+						// and we should get a single layer for the image (no layering)
+						expectedLayerCount := 1
+
+						actualLayerCount := len(manifest.Layers)
+						if actualLayerCount != expectedLayerCount {
+							return fmt.Errorf("expected %d layer from empty layering override, got %d layers",
+								expectedLayerCount, actualLayerCount)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/layering_validation_test.go
+++ b/internal/provider/layering_validation_test.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestLayeringStrategyValidation verifies that the layering strategy validation works.
+func TestLayeringStrategyValidation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"apko": providerserver.NewProtocol6WithError(New("test")()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "apko" {
+  default_layering = {
+    strategy = "invalid-strategy"
+    budget = 5
+  }
+}
+
+resource "apko_build" "test" {
+  repo = "example.com/test"
+  config = jsonencode({
+    contents = {
+      repositories = ["https://packages.wolfi.dev/os"]
+      keyring = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+      packages = ["wolfi-baselayout"]
+    }
+  })
+}
+`,
+				ExpectError: regexp.MustCompile(`Attribute default_layering.strategy value must be one of: \["origin"\]`),
+			},
+		},
+	})
+}
+
+// TestLayeringBudgetValidation verifies that the layering budget validation works.
+func TestLayeringBudgetValidation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"apko": providerserver.NewProtocol6WithError(New("test")()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "apko" {
+  default_layering = {
+    strategy = "origin"
+    budget = 0
+  }
+}
+
+resource "apko_build" "test" {
+  repo = "example.com/test"
+  config = jsonencode({
+    contents = {
+      repositories = ["https://packages.wolfi.dev/os"]
+      keyring = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+      packages = ["wolfi-baselayout"]
+    }
+  })
+}
+`,
+				ExpectError: regexp.MustCompile(`Attribute default_layering.budget value must be at least 1`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
We probably shouldn't use this until `apko` support an empty `layering` object and that's plumbed through here tho.