### PR TITLE
github: print public key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           gpg_private_key: ${{ steps.secrets.outputs.token }}
 
+      - run: |
+          gpg --export --armor ${{ steps.import_gpg.outputs.fingerprint }}
+
       - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: latest


### PR DESCRIPTION
Print public key upon release. This way people know which key was used
at build time to sign.
