### PR TITLE
github: publish signing keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           gpg_private_key: ${{ steps.secrets.outputs.token }}
 
       - run: |
-          gpg --export --armor ${{ steps.import_gpg.outputs.fingerprint }}
+          gpg --keyserver keys.openpgp.org --send-keys ${{ steps.import_gpg.outputs.fingerprint }}
 
       - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:


### PR DESCRIPTION
Publish singing key to the public key signing servers for ease of
verification via Web-of-trust.
