### PR TITLE
bump apko to v0.27.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	chainguard.dev/apko v0.27.1
+	chainguard.dev/apko v0.27.2
 	github.com/chainguard-dev/clog v1.7.0
 	github.com/chainguard-dev/terraform-provider-oci v0.0.21
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-chainguard.dev/apko v0.27.1 h1:+EVA7sii0404daFnH/hGwFDKAxWoj667T6n/ZdW6D38=
-chainguard.dev/apko v0.27.1/go.mod h1:MyEr+sYKtDaTuk0oGSFYL/WFe61iC4vOLnEy2pw8efw=
+chainguard.dev/apko v0.27.2 h1:64l66ucV6GOu/YufB5bg8zeWLuCzVs0VDQcnfAd2OJU=
+chainguard.dev/apko v0.27.2/go.mod h1:vfReRjfh6dIiqxZtMHemV+0yzmUecDfbhnKKROc1z24=
 chainguard.dev/go-grpc-kit v0.17.10 h1:uymMNUIBgbypeIurW25XaXvx3kbS0JpfKsJEMrS0abY=
 chainguard.dev/go-grpc-kit v0.17.10/go.mod h1:RPyCEjTxWAxrODH5V4vJOLy/gHRjEjVF9dzWN+LmIvo=
 chainguard.dev/sdk v0.1.32 h1:pZWN2irtvKMaAkgOpM3LRhuOrlpR3UGhg4F9LVWSyA8=


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/releases/tag/v0.27.2