### PR TITLE
bump to apko 0.27.7

### DIFF
--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -84,7 +84,7 @@ jobs:
     - working-directory: images
       env:
         TF_VAR_target_repository: ttl.sh/tf-apko
-        APKO_IMAGE: ghcr.io/wolfi-dev/apko:latest@sha256:b213d48f4222304390b516ddd3fb98b9ff6cf4d3f542798718d605d0bfa1f599
+        APKO_IMAGE: ghcr.io/wolfi-dev/apko:latest@sha256:1fe0b383c297992721e369cbc9e877f0442fe32a0a0882dc7ace39ffd42a79dc
       run: |
         terraform init
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	chainguard.dev/apko v0.27.5
+	chainguard.dev/apko v0.27.7
 	github.com/chainguard-dev/clog v1.7.0
 	github.com/chainguard-dev/terraform-provider-oci v0.0.22
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-chainguard.dev/apko v0.27.5 h1:Q0zfCX+ctJfO+TfCcbMwrrq8sCspsrORdvmrWrYsI6k=
-chainguard.dev/apko v0.27.5/go.mod h1:50MFlnBotxCgObuO+jWUaJAdUWdm4uheMQl5HR5U3rQ=
+chainguard.dev/apko v0.27.7 h1:FORBBmwslTLVLv4NCt9V90lcDa7LCvJGk6MsfaGilDw=
+chainguard.dev/apko v0.27.7/go.mod h1:50MFlnBotxCgObuO+jWUaJAdUWdm4uheMQl5HR5U3rQ=
 chainguard.dev/go-grpc-kit v0.17.10 h1:uymMNUIBgbypeIurW25XaXvx3kbS0JpfKsJEMrS0abY=
 chainguard.dev/go-grpc-kit v0.17.10/go.mod h1:RPyCEjTxWAxrODH5V4vJOLy/gHRjEjVF9dzWN+LmIvo=
 chainguard.dev/sdk v0.1.32 h1:pZWN2irtvKMaAkgOpM3LRhuOrlpR3UGhg4F9LVWSyA8=


### PR DESCRIPTION
https://github.com/chainguard-dev/terraform-provider-apko/pull/537 and https://github.com/chainguard-dev/terraform-provider-apko/pull/545 need to be bumped together because https://github.com/chainguard-dev/apko/pull/1665/files changed `etc/ld.so.cache`