### PR TITLE
fix version embedding for provider version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,6 @@ builds:
   mod_timestamp: '{{ .CommitTimestamp }}'
   flags:
     - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
     - linux
     - darwin

--- a/internal/provider/layering_validation_test.go
+++ b/internal/provider/layering_validation_test.go
@@ -14,7 +14,7 @@ func TestLayeringStrategyValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"apko": providerserver.NewProtocol6WithError(New("test")()),
+			"apko": providerserver.NewProtocol6WithError(New()()),
 		},
 		Steps: []resource.TestStep{
 			{
@@ -48,7 +48,7 @@ func TestLayeringBudgetValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"apko": providerserver.NewProtocol6WithError(New("test")()),
+			"apko": providerserver.NewProtocol6WithError(New()()),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -206,7 +206,7 @@ func (p *Provider) Functions(ctx context.Context) []func() function.Function {
 	}
 }
 
-// getVersion attempts to get the version from build info
+// getVersion attempts to get the version from build info.
 func getVersion() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		// When built with goreleaser, this will be the actual version

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"runtime/debug"
 	"time"
 
 	"chainguard.dev/apko/pkg/apk/apk"
@@ -205,10 +206,21 @@ func (p *Provider) Functions(ctx context.Context) []func() function.Function {
 	}
 }
 
-func New(version string) func() provider.Provider {
+// getVersion attempts to get the version from build info
+func getVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		// When built with goreleaser, this will be the actual version
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			return info.Main.Version
+		}
+	}
+	return "dev"
+}
+
+func New() func() provider.Provider {
 	return func() provider.Provider {
 		return &Provider{
-			version: version,
+			version: getVersion(),
 		}
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -12,7 +12,7 @@ import (
 // CLI command executed to create a provider server to which the CLI can
 // reattach.
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"apko": providerserver.NewProtocol6WithError(New("test")()),
+	"apko": providerserver.NewProtocol6WithError(New()()),
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/internal/provider/version_function_test.go
+++ b/internal/provider/version_function_test.go
@@ -25,8 +25,9 @@ output "apko_version" {
   value = local.version_info.apko_version
 }`,
 			Check: resource.ComposeTestCheckFunc(
-				// Check that the provider version is "test" (as set in testAccProtoV6ProviderFactories)
-				resource.TestCheckOutput("provider_version", "test"),
+				// Check that the provider version is not empty and looks like a version
+				// With build info, it should be something like "v0.23.1-0.20250729145754-7f4b7167d62c" or "test"
+				resource.TestMatchOutput("provider_version", regexp.MustCompile(`^(v\d+\.\d+\.\d+.*|test|\(devel\)|dev)$`)),
 				// Check that apko version is not empty and looks like a version
 				resource.TestMatchOutput("apko_version", regexp.MustCompile(`^v\d+\.\d+\.\d+.*|unknown$`)),
 			),

--- a/internal/provider/version_function_test.go
+++ b/internal/provider/version_function_test.go
@@ -27,7 +27,7 @@ output "apko_version" {
 			Check: resource.ComposeTestCheckFunc(
 				// Check that the provider version is not empty and looks like a version
 				// With build info, it should be something like "v0.23.1-0.20250729145754-7f4b7167d62c" or "test"
-				resource.TestMatchOutput("provider_version", regexp.MustCompile(`^(v\d+\.\d+\.\d+.*|test|\(devel\)|dev)$`)),
+				resource.TestMatchOutput("provider_version", regexp.MustCompile(`^(v\d+\.\d+\.\d+.*|dev)$`)),
 				// Check that apko version is not empty and looks like a version
 				resource.TestMatchOutput("apko_version", regexp.MustCompile(`^v\d+\.\d+\.\d+.*|unknown$`)),
 			),

--- a/internal/provider/version_function_test.go
+++ b/internal/provider/version_function_test.go
@@ -26,7 +26,7 @@ output "apko_version" {
 }`,
 			Check: resource.ComposeTestCheckFunc(
 				// Check that the provider version is not empty and looks like a version
-				// With build info, it should be something like "v0.23.1-0.20250729145754-7f4b7167d62c" or "test"
+				// With build info, it should be something like "v0.23.1-0.20250729145754-7f4b7167d62c" or "dev"
 				resource.TestMatchOutput("provider_version", regexp.MustCompile(`^(v\d+\.\d+\.\d+.*|dev)$`)),
 				// Check that apko version is not empty and looks like a version
 				resource.TestMatchOutput("apko_version", regexp.MustCompile(`^v\d+\.\d+\.\d+.*|unknown$`)),

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"log/slog"
+	"runtime/debug"
 
 	"github.com/chainguard-dev/terraform-provider-apko/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -14,7 +15,13 @@ import (
 //go:generate terraform fmt -recursive ./examples/
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-const version string = "dev"
+// getVersion returns the version from build info, falling back to "dev" if not available
+func getVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		return info.Main.Version
+	}
+	return "dev"
+}
 
 func main() {
 	var debug bool
@@ -26,7 +33,7 @@ func main() {
 		Debug:   debug,
 	}
 
-	if err := providerserver.Serve(context.Background(), provider.New(version), opts); err != nil {
+	if err := providerserver.Serve(context.Background(), provider.New(getVersion()), opts); err != nil {
 		log.Fatal(err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"log"
 	"log/slog"
-	"runtime/debug"
 
 	"github.com/chainguard-dev/terraform-provider-apko/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -14,14 +13,6 @@ import (
 
 //go:generate terraform fmt -recursive ./examples/
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
-
-// getVersion returns the version from build info, falling back to "dev" if not available.
-func getVersion() string {
-	if info, ok := debug.ReadBuildInfo(); ok {
-		return info.Main.Version
-	}
-	return "dev"
-}
 
 func main() {
 	var debug bool
@@ -33,7 +24,7 @@ func main() {
 		Debug:   debug,
 	}
 
-	if err := providerserver.Serve(context.Background(), provider.New(getVersion()), opts); err != nil {
+	if err := providerserver.Serve(context.Background(), provider.New(), opts); err != nil {
 		log.Fatal(err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 //go:generate terraform fmt -recursive ./examples/
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-// getVersion returns the version from build info, falling back to "dev" if not available
+// getVersion returns the version from build info, falling back to "dev" if not available.
 func getVersion() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		return info.Main.Version


### PR DESCRIPTION
Setting version using ldflags is brittle, and seems not to work the way goreleaser does it today. Instead, let's just get our version from `BuildInfo` which is more reliable.