### PR TITLE
ci: Run registry on disk rather than in-memory

### DIFF
--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -115,6 +115,7 @@ jobs:
     - uses: chainguard-dev/actions/setup-registry@d67380d0b02c09412f8e17f660ec48870bd89e6e # v1.6.9
       with:
         port: 5005
+        disk: true
 
     - name: Build images using current providers, and current reproducibility tests
       working-directory: images


### PR DESCRIPTION
We're currently running the registry entirely in-memory, which might be contributing to the heavy flakiness we're seeing.