### PR TITLE
fix(ci): Reduce terraform parallelism from 10 to 4

### DIFF
--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -125,7 +125,7 @@ jobs:
         terraform init
 
         # First do a stock build, to populate imagetest repo with current apko provider
-        terraform apply -auto-approve \
+        terraform apply -auto-approve -parallelism=4 \
           -target=module.go \
           -target=module.jdk \
           -target=module.python \
@@ -150,7 +150,7 @@ jobs:
 
         # This should not fail, and there is a proof just above that
         # we have just successfully built things
-        terraform apply -auto-approve \
+        terraform apply -auto-approve -parallelism=4 \
           -target=module.go \
           -target=module.jdk \
           -target=module.python


### PR DESCRIPTION
This potentially mitigates timeouts from sigstore/registry contention