### PR TITLE
ci: remove module.python from mega-module targets

### DIFF
--- a/.github/workflows/mega-module.yaml
+++ b/.github/workflows/mega-module.yaml
@@ -128,7 +128,6 @@ jobs:
         terraform apply -auto-approve \
           -target=module.go \
           -target=module.jdk \
-          -target=module.python \
           -target=module.kubernetes
 
     - name: Build images using the new provider, and potentially new reproducibility tests
@@ -152,8 +151,7 @@ jobs:
         # we have just successfully built things
         terraform apply -auto-approve \
           -target=module.go \
-          -target=module.jdk \
-          -target=module.python
+          -target=module.jdk
 
     - name: Upload imagetest logs
       if: always()


### PR DESCRIPTION
## Summary

- Remove `module.python` from both `terraform apply` targets in the mega-module workflow
- The python-dev image has a 2.5MB SBOM — 7x larger than any other image in the test matrix
- Each `cosign_attest` resource uploads the full base64-encoded SBOM as an intoto entry to Rekor, making python-dev attestations the dominant contributor to Sigstore API load during CI
- The go and jdk modules (with their -dev variants) exercise the same provider code paths

### SBOM sizes by image (amd64)

| Image | SBOM | Base64 for Rekor |
|-------|------|-----------------|
| python-dev | **2,602 KB** | **~3,470 KB** |
| go-dev | 373 KB | ~497 KB |
| jdk-dev | 374 KB | ~499 KB |
| go | 362 KB | ~483 KB |
| jdk | 228 KB | ~304 KB |
| python | 156 KB | ~208 KB |

Alternative to #820 (parallelism reduction). Can be combined with it for belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)