### PR TITLE
fix(release): use hkps:// for GPG keyserver to fix harden-runner block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         run: |
-          gpg --keyserver keys.openpgp.org --send-keys "$GPG_FINGERPRINT"
+          gpg --keyserver hkps://keys.openpgp.org --send-keys "$GPG_FINGERPRINT"
 
       - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         if: steps.check.outputs.need_release == 'yes'


### PR DESCRIPTION
Without an explicit scheme, GPG defaults to hkp:// (port 80), which is blocked by the harden-runner egress policy. Using hkps:// forces TLS on port 443, which is already in the allowlist.