### PR TITLE
fix(release): allow dirmngr SRV lookup for GPG keyserver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
             go.dev:443
             goreleaser.com:443
             iamcredentials.googleapis.com:443
+            _pgpkey-https._tcp.keys.openpgp.org:443
             keys.openpgp.org:11371
             keys.openpgp.org:443
             objects.githubusercontent.com:443


### PR DESCRIPTION
## Summary
- GPG's `dirmngr` does a DNS SRV lookup for `_pgpkey-https._tcp.keys.openpgp.org` before connecting to `keys.openpgp.org`, and harden-runner treats this as a separate endpoint
- Add `_pgpkey-https._tcp.keys.openpgp.org:443` to allowed-endpoints, matching the pattern already used in `terraform-provider-cosign`
- Fixes the release workflow failure in https://github.com/chainguard-dev/terraform-provider-apko/actions/runs/24800104335

## Test plan
- [ ] Re-run the release workflow and verify the GPG key upload step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)