### PR TITLE
release: Use audit policy for now to unblock release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             *.blob.core.windows.net:443
             *.githubapp.com:443


### PR DESCRIPTION
This aligns the release flow with that of the helm, imagetest and cosign providers.