### PR TITLE
Add optional oci_layout_path to apko_build

### DIFF
--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -61,6 +61,7 @@ resource "apko_build" "example" {
 ### Optional
 
 - `configs` (Attributes Map) A map from the APK architecture to the config for that architecture. (see [below for nested schema](#nestedatt--configs))
+- `oci_layout_path` (String) Optional local filesystem path to write an OCI image layout of the built image. When set, the layout is written to this path after the build (creating the directory if needed). The caller owns the directory lifecycle. Leave unset to skip the layout write.
 - `sboms` (Attributes Map) A map from the APK architecture to the digest for that architecture and its SBOM. (see [below for nested schema](#nestedatt--sboms))
 
 ### Read-Only

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -20,6 +20,7 @@ import (
 	"github.com/chainguard-dev/clog"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -114,6 +115,19 @@ type imagesbom struct {
 	predicateType   string
 	predicatePath   string
 	predicateSHA256 string
+}
+
+// writeImageLayout writes the given image index as an OCI image layout to the
+// caller-supplied path. The caller owns the directory lifecycle (e.g. an
+// execroot that is torn down by the build driver).
+func writeImageLayout(dir string, ii v1.ImageIndex) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create layout dir %q: %w", dir, err)
+	}
+	if _, err := layout.Write(dir, ii); err != nil {
+		return fmt.Errorf("write layout: %w", err)
+	}
+	return nil
 }
 
 func doBuild(ctx context.Context, data BuildResourceModel, tempDir string) (v1.Hash, v1.ImageIndex, map[string]imagesbom, error) {

--- a/internal/provider/resource_build.go
+++ b/internal/provider/resource_build.go
@@ -36,11 +36,12 @@ type BuildResource struct {
 }
 
 type BuildResourceModel struct {
-	Id       types.String `tfsdk:"id"`
-	Repo     types.String `tfsdk:"repo"`
-	Config   types.Object `tfsdk:"config"`
-	Configs  types.Map    `tfsdk:"configs"`
-	ImageRef types.String `tfsdk:"image_ref"`
+	Id            types.String `tfsdk:"id"`
+	Repo          types.String `tfsdk:"repo"`
+	Config        types.Object `tfsdk:"config"`
+	Configs       types.Map    `tfsdk:"configs"`
+	ImageRef      types.String `tfsdk:"image_ref"`
+	OciLayoutPath types.String `tfsdk:"oci_layout_path"`
 
 	SBOMs types.Map `tfsdk:"sboms"`
 
@@ -125,6 +126,10 @@ func (r *BuildResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: "The resulting fully-qualified digest (e.g. {repo}@sha256:deadbeef).",
 				Computed:            true,
 			},
+			"oci_layout_path": schema.StringAttribute{
+				MarkdownDescription: "Optional local filesystem path to write an OCI image layout of the built image. When set, the layout is written to this path after the build (creating the directory if needed). The caller owns the directory lifecycle. Leave unset to skip the layout write.",
+				Optional:            true,
+			},
 			"sboms": schema.MapNestedAttribute{
 				MarkdownDescription: "A map from the APK architecture to the digest for that architecture and its SBOM.",
 				Computed:            true,
@@ -190,6 +195,13 @@ func (r *BuildResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 	dig := repo.Digest(digest.String())
+
+	if p := data.OciLayoutPath.ValueString(); p != "" {
+		if err := writeImageLayout(p, se); err != nil {
+			resp.Diagnostics.AddError("Client Error", err.Error())
+			return
+		}
+	}
 
 	pushable, ok := se.(remote.Taggable)
 	if !ok {

--- a/internal/provider/resource_build_test.go
+++ b/internal/provider/resource_build_test.go
@@ -13,6 +13,7 @@ import (
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	ocitesting "github.com/chainguard-dev/terraform-provider-oci/testing"
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -492,4 +493,75 @@ resource "apko_build" "foo" {
 	if got, want := len(m.Layers), 5; got != want {
 		t.Errorf("len(layers): %d, want %d", got, want)
 	}
+}
+
+// TestAccResourceApkoBuild_OciLayoutPath verifies that when oci_layout_path is
+// set, the resource writes a valid OCI image layout to that directory and the
+// image inside has the same digest as the pushed image_ref.
+func TestAccResourceApkoBuild_OciLayoutPath(t *testing.T) {
+	repo, cleanup := ocitesting.SetupRepository(t, "test")
+	defer cleanup()
+	repostr := repo.String()
+
+	// Use a path under TempDir that does not exist yet — the provider should
+	// create it via MkdirAll.
+	layoutDir := t.TempDir() + "/layout"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"apko": providerserver.NewProtocol6WithError(&Provider{
+				repositories:       []string{"https://packages.wolfi.dev/os"},
+				buildRespositories: []string{"./packages"},
+				keyring:            []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
+				archs:              []string{"x86_64"},
+				packages:           []string{"wolfi-baselayout=20230201-r24"},
+			}),
+		},
+		Steps: []resource.TestStep{{
+			Config: fmt.Sprintf(`
+data "apko_config" "foo" {
+  config_contents = <<EOF
+contents:
+  packages:
+  - ca-certificates-bundle=20250911-r0
+  - glibc-locale-posix=2.42-r2
+  - tzdata=2025b-r2
+EOF
+}
+
+resource "apko_build" "foo" {
+  repo            = %q
+  config          = data.apko_config.foo.config
+  oci_layout_path = %q
+}
+`, repostr, layoutDir),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("apko_build.foo", "oci_layout_path", layoutDir),
+				resource.TestCheckFunc(func(s *terraform.State) error {
+					rs, ok := s.RootModule().Resources["apko_build.foo"]
+					if !ok {
+						return errors.New("apko_build.foo not in state")
+					}
+					p, err := layout.FromPath(layoutDir)
+					if err != nil {
+						return fmt.Errorf("layout.FromPath(%q): %w", layoutDir, err)
+					}
+					idx, err := p.ImageIndex()
+					if err != nil {
+						return fmt.Errorf("reading layout index: %w", err)
+					}
+					d, err := idx.Digest()
+					if err != nil {
+						return fmt.Errorf("layout digest: %w", err)
+					}
+					want := rs.Primary.Attributes["image_ref"]
+					if got := repo.Digest(d.String()).String(); got != want {
+						return fmt.Errorf("layout digest %s != image_ref %s", got, want)
+					}
+					return nil
+				}),
+			),
+		}},
+	})
 }


### PR DESCRIPTION
When set, apko_build writes an OCI image layout of the built multi-arch image to the given filesystem path after the build. This lets downstream tooling (notably oci_structure_test) read the image without a registry round trip — apko already has the v1.ImageIndex in memory, so we can hand it off directly instead of pushing it and pulling it back. The caller supplies the path and owns its lifecycle, so the provider stays out of cleanup decisions; leaving the attribute unset preserves today's behavior exactly.
