### PR TITLE
fix(ci): repair Tests (stale nodejs pin) and Image digest update (gitsign endpoints)

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -30,7 +30,9 @@ jobs:
           ghcr.io:443
           github.com:443
           octo-sts.dev:443
+          rekor.sigstore.dev:443
           release-assets.githubusercontent.com:443
+          tuf-repo-cdn.sigstore.dev:443
 
     - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
       id: octo-sts

--- a/internal/provider/tags_data_source_test.go
+++ b/internal/provider/tags_data_source_test.go
@@ -28,7 +28,7 @@ contents:
   - ca-certificates-bundle=20250911-r0
   - glibc-locale-posix=2.42-r2
   - ko=0.18.0-r6
-  - nodejs=21.7.3-r9 # Initial request will be satisfied by 'provides'
+  - nodejs=24.18.0-r1 # Initial request will be satisfied by 'provides'
 EOF
   extra_packages = ["tzdata=2025b-r2"]
 }
@@ -63,9 +63,9 @@ data "apko_tags" "nodejs" {
   target_package = "nodejs" # Tags can be inferred from 'provides'
 }
 
-data "apko_tags" "nodejs-21" {
+data "apko_tags" "nodejs-24" {
   config         = data.apko_config.this.config
-  target_package = "nodejs-21"
+  target_package = "nodejs-24"
 }
 `,
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -98,20 +98,20 @@ data "apko_tags" "nodejs-21" {
 				resource.TestCheckResourceAttr("data.apko_tags.ko", "id", "0,0.18,0.18.0,0.18.0-r6"),
 
 				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.#", "4"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.0", "21"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.1", "21.7"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.2", "21.7.3"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.3", "21.7.3-r9"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "id", "21,21.7,21.7.3,21.7.3-r9"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.0", "24"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.1", "24.18"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.2", "24.18.0"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "tags.3", "24.18.0-r1"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs", "id", "24,24.18,24.18.0,24.18.0-r1"),
 
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.#", "4"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.0", "21"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.1", "21.7"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.2", "21.7.3"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "tags.3", "21.7.3-r9"),
-				resource.TestCheckResourceAttr("data.apko_tags.nodejs-21", "id", "21,21.7,21.7.3,21.7.3-r9"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-24", "tags.#", "4"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-24", "tags.0", "24"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-24", "tags.1", "24.18"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-24", "tags.2", "24.18.0"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-24", "tags.3", "24.18.0-r1"),
+				resource.TestCheckResourceAttr("data.apko_tags.nodejs-24", "id", "24,24.18,24.18.0,24.18.0-r1"),
 
-				//21.7.3-r9.apk
+				//24.18.0-r1.apk
 			),
 		}},
 	})
@@ -139,7 +139,7 @@ contents:
   - ca-certificates-bundle=20250911-r0
   - glibc-locale-posix=2.42-r2
   - ko=0.18.0-r6
-  - nodejs=21.7.3-r9
+  - nodejs=24.18.0-r1
 EOF
   extra_packages = ["tzdata=2025b-r2"]
 }


### PR DESCRIPTION
## Summary

Two independent CI failures are fixed here, one commit each.

### Tests workflow — stale nodejs pin
`TestAccDataSourceTags` pinned `nodejs=21.7.3-r9`, but Wolfi has removed the
nodejs-21 package. apko could no longer resolve the request ("computing package
locks"), failing the Tests workflow on every PR and push.

Repointed the fixture at nodejs-24 (`24.18.0-r1`), which provides
`nodejs=24.18.0-r1` — exercising the same "satisfied by provides" path the test
was written to cover. Updated the second data source (`nodejs-21` → `nodejs-24`)
and the expected tag/id assertions.

Verified locally: `TF_ACC=1 go test -cover ./internal/provider/` → ok, 69.8% cover.

### Image digest update workflow — gitsign egress block
The nightly job fails when digestabot signs its commit with gitsign:
harden-runner's egress block denied the sigstore TUF root fetch
(`tuf-repo-cdn.sigstore.dev`), surfacing as "gpg failed to sign the data" /
"operation not permitted".

Added the two sigstore endpoints gitsign needs that weren't already allowed:
- `tuf-repo-cdn.sigstore.dev:443` — TUF root/targets (the observed block)
- `rekor.sigstore.dev:443` — transparency-log upload, next in the signing flow

`fulcio.sigstore.dev` was already present. Entries kept alphabetical in the
existing block scalar. actionlint + zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)