### PR TITLE
Strip contents.runtime_keyring from the generated schema

### DIFF
--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -95,17 +95,7 @@ Optional:
 - `keyring` (List of String)
 - `packages` (List of String)
 - `repositories` (List of String)
-- `runtime_keyring` (List of Object) (see [below for nested schema](#nestedobjatt--configs--config--contents--runtime_keyring))
 - `runtime_repositories` (List of String)
-
-<a id="nestedobjatt--configs--config--contents--runtime_keyring"></a>
-### Nested Schema for `configs.config.contents.runtime_keyring`
-
-Optional:
-
-- `content` (String)
-- `name` (String)
-
 
 
 <a id="nestedobjatt--configs--config--entrypoint"></a>
@@ -205,17 +195,7 @@ Read-Only:
 - `keyring` (List of String)
 - `packages` (List of String)
 - `repositories` (List of String)
-- `runtime_keyring` (List of Object) (see [below for nested schema](#nestedobjatt--config--contents--runtime_keyring))
 - `runtime_repositories` (List of String)
-
-<a id="nestedobjatt--config--contents--runtime_keyring"></a>
-### Nested Schema for `config.contents.runtime_keyring`
-
-Read-Only:
-
-- `content` (String)
-- `name` (String)
-
 
 
 <a id="nestedobjatt--config--entrypoint"></a>

--- a/docs/data-sources/tags.md
+++ b/docs/data-sources/tags.md
@@ -86,17 +86,7 @@ Required:
 - `keyring` (List of String)
 - `packages` (List of String)
 - `repositories` (List of String)
-- `runtime_keyring` (List of Object) (see [below for nested schema](#nestedobjatt--config--contents--runtime_keyring))
 - `runtime_repositories` (List of String)
-
-<a id="nestedobjatt--config--contents--runtime_keyring"></a>
-### Nested Schema for `config.contents.runtime_keyring`
-
-Required:
-
-- `content` (String)
-- `name` (String)
-
 
 
 <a id="nestedobjatt--config--entrypoint"></a>

--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -130,17 +130,7 @@ Required:
 - `keyring` (List of String)
 - `packages` (List of String)
 - `repositories` (List of String)
-- `runtime_keyring` (List of Object) (see [below for nested schema](#nestedobjatt--config--contents--runtime_keyring))
 - `runtime_repositories` (List of String)
-
-<a id="nestedobjatt--config--contents--runtime_keyring"></a>
-### Nested Schema for `config.contents.runtime_keyring`
-
-Required:
-
-- `content` (String)
-- `name` (String)
-
 
 
 <a id="nestedobjatt--config--entrypoint"></a>
@@ -246,17 +236,7 @@ Optional:
 - `keyring` (List of String)
 - `packages` (List of String)
 - `repositories` (List of String)
-- `runtime_keyring` (List of Object) (see [below for nested schema](#nestedobjatt--configs--config--contents--runtime_keyring))
 - `runtime_repositories` (List of String)
-
-<a id="nestedobjatt--configs--config--contents--runtime_keyring"></a>
-### Nested Schema for `configs.config.contents.runtime_keyring`
-
-Optional:
-
-- `content` (String)
-- `name` (String)
-
 
 
 <a id="nestedobjatt--configs--config--entrypoint"></a>

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -58,49 +58,6 @@ var strippedAttrPaths = [][]string{
 	{"contents", "runtime_keyring"},
 }
 
-// stripAttrType removes the attribute at the given path from the object type.
-func stripAttrType(t basetypes.ObjectType, path []string) basetypes.ObjectType {
-	if len(path) == 1 {
-		delete(t.AttrTypes, path[0])
-		return t
-	}
-	child, ok := t.AttrTypes[path[0]].(basetypes.ObjectType)
-	if !ok {
-		panic(fmt.Sprintf("expected %q to be an object type", path[0]))
-	}
-	t.AttrTypes[path[0]] = stripAttrType(child, path[1:])
-	return t
-}
-
-// stripAttrs removes the attribute at the given path from the attribute map,
-// rebuilding nested object values against the given (already stripped) type
-// as needed. The caller rebuilds the top-level object once all paths are
-// stripped.
-func stripAttrs(attrs map[string]attr.Value, t basetypes.ObjectType, path []string) diag.Diagnostics {
-	if len(path) == 1 {
-		delete(attrs, path[0])
-		return nil
-	}
-	childVal, ok := attrs[path[0]].(basetypes.ObjectValue)
-	if !ok {
-		return nil
-	}
-	childType, ok := t.AttrTypes[path[0]].(basetypes.ObjectType)
-	if !ok {
-		return nil
-	}
-	childAttrs := childVal.Attributes()
-	if diags := stripAttrs(childAttrs, childType, path[1:]); diags.HasError() {
-		return diags
-	}
-	newChild, diags := types.ObjectValue(childType.AttrTypes, childAttrs)
-	if diags.HasError() {
-		return diags
-	}
-	attrs[path[0]] = newChild
-	return diags
-}
-
 func init() {
 	sch, err := generateType(apkotypes.ImageConfiguration{})
 	if err != nil {

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -48,6 +48,59 @@ type ConfigDataSourceModel struct {
 var imageConfigurationSchema basetypes.ObjectType
 var imageConfigurationsSchema basetypes.ObjectType
 
+// TODO: These attributes are optional, but our schema generation using
+// schema.ObjectAttribute with AttributeTypes doesn't support field-level
+// optional/required controls. For now, remove them from the schema type
+// definition and from generated values in the Read method until we figure
+// out optional types.
+var strippedAttrPaths = [][]string{
+	{"certificates"},
+	{"contents", "runtime_keyring"},
+}
+
+// stripAttrType removes the attribute at the given path from the object type.
+func stripAttrType(t basetypes.ObjectType, path []string) basetypes.ObjectType {
+	if len(path) == 1 {
+		delete(t.AttrTypes, path[0])
+		return t
+	}
+	child, ok := t.AttrTypes[path[0]].(basetypes.ObjectType)
+	if !ok {
+		panic(fmt.Sprintf("expected %q to be an object type", path[0]))
+	}
+	t.AttrTypes[path[0]] = stripAttrType(child, path[1:])
+	return t
+}
+
+// stripAttrs removes the attribute at the given path from the attribute map,
+// rebuilding nested object values against the given (already stripped) type
+// as needed. The caller rebuilds the top-level object once all paths are
+// stripped.
+func stripAttrs(attrs map[string]attr.Value, t basetypes.ObjectType, path []string) diag.Diagnostics {
+	if len(path) == 1 {
+		delete(attrs, path[0])
+		return nil
+	}
+	childVal, ok := attrs[path[0]].(basetypes.ObjectValue)
+	if !ok {
+		return nil
+	}
+	childType, ok := t.AttrTypes[path[0]].(basetypes.ObjectType)
+	if !ok {
+		return nil
+	}
+	childAttrs := childVal.Attributes()
+	if diags := stripAttrs(childAttrs, childType, path[1:]); diags.HasError() {
+		return diags
+	}
+	newChild, diags := types.ObjectValue(childType.AttrTypes, childAttrs)
+	if diags.HasError() {
+		return diags
+	}
+	attrs[path[0]] = newChild
+	return diags
+}
+
 func init() {
 	sch, err := generateType(apkotypes.ImageConfiguration{})
 	if err != nil {
@@ -60,11 +113,9 @@ func init() {
 		panic("expected object type")
 	}
 
-	// TODO: Certificates are optional, but our schema generation using
-	// schema.ObjectAttribute with AttributeTypes doesn't support field-level
-	// optional/required controls. For now, remove certificates from the schema
-	// type definition. We also remove it from generated values in the Read method.
-	delete(imageConfigurationSchema.AttrTypes, "certificates")
+	for _, path := range strippedAttrPaths {
+		imageConfigurationSchema = stripAttrType(imageConfigurationSchema, path)
+	}
 
 	imageConfigurationsSchema = basetypes.ObjectType{
 		AttrTypes: map[string]attr.Type{
@@ -232,10 +283,15 @@ func (d *ConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 			return
 		}
 
-		// Remove certificates from the generated value to match the schema
-		// TODO: see above about optional types.
+		// Remove stripped attributes from the generated value to match the
+		// schema. TODO: see above about optional types.
 		attrs := cfg.Attributes()
-		delete(attrs, "certificates")
+		for _, path := range strippedAttrPaths {
+			resp.Diagnostics.Append(stripAttrs(attrs, imageConfigurationSchema, path)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+		}
 		cfg, diags = types.ObjectValue(imageConfigurationSchema.AttrTypes, attrs)
 		resp.Diagnostics = append(resp.Diagnostics, diags...)
 		if diags.HasError() {

--- a/internal/provider/strip.go
+++ b/internal/provider/strip.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// stripAttrType removes the attribute at the given path from the object type.
+func stripAttrType(t basetypes.ObjectType, path []string) basetypes.ObjectType {
+	if len(path) == 1 {
+		delete(t.AttrTypes, path[0])
+		return t
+	}
+	child, ok := t.AttrTypes[path[0]].(basetypes.ObjectType)
+	if !ok {
+		panic(fmt.Sprintf("expected %q to be an object type", path[0]))
+	}
+	t.AttrTypes[path[0]] = stripAttrType(child, path[1:])
+	return t
+}
+
+// stripAttrs removes the attribute at the given path from the attribute map,
+// rebuilding nested object values against the given (already stripped) type
+// as needed. The caller rebuilds the top-level object once all paths are
+// stripped.
+func stripAttrs(attrs map[string]attr.Value, t basetypes.ObjectType, path []string) diag.Diagnostics {
+	if len(path) == 1 {
+		delete(attrs, path[0])
+		return nil
+	}
+	childVal, ok := attrs[path[0]].(basetypes.ObjectValue)
+	if !ok {
+		return nil
+	}
+	childType, ok := t.AttrTypes[path[0]].(basetypes.ObjectType)
+	if !ok {
+		return nil
+	}
+	childAttrs := childVal.Attributes()
+	if diags := stripAttrs(childAttrs, childType, path[1:]); diags.HasError() {
+		return diags
+	}
+	newChild, diags := types.ObjectValue(childType.AttrTypes, childAttrs)
+	if diags.HasError() {
+		return diags
+	}
+	attrs[path[0]] = newChild
+	return diags
+}

--- a/internal/provider/strip_test.go
+++ b/internal/provider/strip_test.go
@@ -1,0 +1,181 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func contentsAttrTypes(t *testing.T, obj basetypes.ObjectType) map[string]attr.Type {
+	t.Helper()
+	contents, ok := obj.AttrTypes["contents"].(basetypes.ObjectType)
+	if !ok {
+		t.Fatalf("expected contents to be an object type, got %T", obj.AttrTypes["contents"])
+	}
+	return contents.AttrTypes
+}
+
+func testObjectType() basetypes.ObjectType {
+	return basetypes.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"certificates": basetypes.StringType{},
+			"cmd":          basetypes.StringType{},
+			"contents": basetypes.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"packages":        basetypes.ListType{ElemType: basetypes.StringType{}},
+					"runtime_keyring": basetypes.ListType{ElemType: basetypes.StringType{}},
+				},
+			},
+		},
+	}
+}
+
+func TestStripAttrType(t *testing.T) {
+	tests := []struct {
+		name string
+		path []string
+		want basetypes.ObjectType
+	}{{
+		name: "top-level attribute",
+		path: []string{"certificates"},
+		want: basetypes.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"cmd": basetypes.StringType{},
+				"contents": basetypes.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"packages":        basetypes.ListType{ElemType: basetypes.StringType{}},
+						"runtime_keyring": basetypes.ListType{ElemType: basetypes.StringType{}},
+					},
+				},
+			},
+		},
+	}, {
+		name: "nested attribute",
+		path: []string{"contents", "runtime_keyring"},
+		want: basetypes.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"certificates": basetypes.StringType{},
+				"cmd":          basetypes.StringType{},
+				"contents": basetypes.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"packages": basetypes.ListType{ElemType: basetypes.StringType{}},
+					},
+				},
+			},
+		},
+	}, {
+		name: "missing attribute is a no-op",
+		path: []string{"does_not_exist"},
+		want: basetypes.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"certificates": basetypes.StringType{},
+				"cmd":          basetypes.StringType{},
+				"contents": basetypes.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"packages":        basetypes.ListType{ElemType: basetypes.StringType{}},
+						"runtime_keyring": basetypes.ListType{ElemType: basetypes.StringType{}},
+					},
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := stripAttrType(testObjectType(), test.path)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("stripAttrType(%v) mismatch (-got, +want):\n%s", test.path, diff)
+			}
+		})
+	}
+}
+
+func TestStripAttrTypePanicsOnNonObject(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic when traversing through a non-object attribute")
+		}
+	}()
+	stripAttrType(testObjectType(), []string{"cmd", "nested"})
+}
+
+func TestStripAttrs(t *testing.T) {
+	// The stripped type, i.e. what values must conform to after stripping.
+	strippedType := testObjectType()
+	for _, path := range [][]string{{"certificates"}, {"contents", "runtime_keyring"}} {
+		strippedType = stripAttrType(strippedType, path)
+	}
+
+	packages, diags := types.ListValue(basetypes.StringType{}, []attr.Value{types.StringValue("foo=1.2.3")})
+	if diags.HasError() {
+		t.Fatalf("ListValue: %v", diags)
+	}
+	keyring, diags := types.ListValue(basetypes.StringType{}, []attr.Value{types.StringValue("key")})
+	if diags.HasError() {
+		t.Fatalf("ListValue: %v", diags)
+	}
+	contents, diags := types.ObjectValue(contentsAttrTypes(t, testObjectType()), map[string]attr.Value{
+		"packages":        packages,
+		"runtime_keyring": keyring,
+	})
+	if diags.HasError() {
+		t.Fatalf("ObjectValue: %v", diags)
+	}
+
+	attrs := map[string]attr.Value{
+		"certificates": types.StringValue("cert"),
+		"cmd":          types.StringValue("/bin/sh"),
+		"contents":     contents,
+	}
+
+	// Strip all paths first, then rebuild the top-level object once, exactly
+	// like the Read method does. Rebuilding per path would fail because the
+	// value would still hold attributes pending removal by a later path.
+	for _, path := range [][]string{{"certificates"}, {"contents", "runtime_keyring"}} {
+		if diags := stripAttrs(attrs, strippedType, path); diags.HasError() {
+			t.Fatalf("stripAttrs(%v): %v", path, diags)
+		}
+	}
+
+	got, diags := types.ObjectValue(strippedType.AttrTypes, attrs)
+	if diags.HasError() {
+		t.Fatalf("ObjectValue after strip: %v", diags)
+	}
+
+	wantContents, diags := types.ObjectValue(contentsAttrTypes(t, strippedType), map[string]attr.Value{
+		"packages": packages,
+	})
+	if diags.HasError() {
+		t.Fatalf("ObjectValue: %v", diags)
+	}
+	want, diags := types.ObjectValue(strippedType.AttrTypes, map[string]attr.Value{
+		"cmd":      types.StringValue("/bin/sh"),
+		"contents": wantContents,
+	})
+	if diags.HasError() {
+		t.Fatalf("ObjectValue: %v", diags)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("stripped value mismatch (-got, +want):\n%s", diff)
+	}
+}
+
+func TestStripAttrsMissingIsNoop(t *testing.T) {
+	attrs := map[string]attr.Value{
+		"cmd": types.StringValue("/bin/sh"),
+	}
+	// Neither the attribute nor the nested parent exist; both must be no-ops.
+	if diags := stripAttrs(attrs, testObjectType(), []string{"does_not_exist"}); diags.HasError() {
+		t.Fatalf("stripAttrs: %v", diags)
+	}
+	if diags := stripAttrs(attrs, testObjectType(), []string{"missing_parent", "child"}); diags.HasError() {
+		t.Fatalf("stripAttrs: %v", diags)
+	}
+	if len(attrs) != 1 {
+		t.Errorf("expected attrs to be unchanged, got %v", attrs)
+	}
+}


### PR DESCRIPTION
apko v1.2.23 added runtime_keyring to ImageContents, and the provider picked it up with the bump to apko v1.2.32. Our reflective schema generation makes every attribute required, so consumers that construct config objects (e.g. from jsondecode'd locked configs, where omitempty drops the field) fail with "attribute runtime_keyring is required". Generalize the existing certificates workaround into a list of stripped attribute paths that are removed from both the schema type and generated values, and add contents.runtime_keyring to it.